### PR TITLE
Single-tier gpt-5.5 review (retire cheap->strong cascade)

### DIFF
--- a/.github/workflows/self-review.yml
+++ b/.github/workflows/self-review.yml
@@ -6,25 +6,29 @@
 #
 # Trigger is `pull_request` (NOT pull_request_target) on purpose: pull_request_target
 # would run the action from the base branch (main), which would test the OLD code,
-# not the PR's. Same-repo PRs (branches pushed straight to this repo) still receive
-# secrets and a write token under `pull_request`, so the review can post + gate.
+# not the PR's. The job is gated to SAME-REPO PRs (head repo == this repo): those
+# get secrets + a write token so the review can post + gate. Fork PRs are skipped
+# outright — they never see the secret (would fail the check), and running their
+# PR-controlled `uses: ./` code with the key would be a secret-exfil vector.
+#
+# ACCEPTED RISK: a same-repo PR still runs its own (PR-controlled) action code with
+# the real secret. That is inherent to `uses: ./` self-testing and is bounded to
+# people with push access to this repo (a trusted set) — the same trust GitHub
+# already grants them. There is no on-demand comment trigger: to re-review without
+# a new push, re-run this workflow from the Actions tab.
 #
 # COST: every run spends real, wallet-metered OrcaRouter quota. Requires the
-# `ORCAROUTER_API_KEY` secret on this repo. Fork PRs never see that secret, so the
-# job condition below skips them outright (head repo != this repo) — otherwise they
-# would reach the action with an empty key and fail the required check, not "skip".
+# `ORCAROUTER_API_KEY` secret on this repo.
 
 name: Self-review
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
-  issue_comment:
-    types: [created]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -34,29 +38,14 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
-    # Auto-run on PR events, or on demand when a maintainer comments
-    # `/orcarouter-review` (lets you re-review without a new push, and gates the
-    # paid run to owner/member/collaborator).
-    if: |
-      (github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        startsWith(github.event.comment.body, '/orcarouter-review') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    # Same-repo PRs only: fork PRs get no secret and must not run PR-controlled
+    # action code with the key.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       # Required so the local `uses: ./` action definition is present in the
-      # workspace. For pull_request, github.ref is already the PR merge ref, so `./`
-      # resolves to the action code being changed by the PR. For issue_comment
-      # (/orcarouter-review) the event carries no PR ref, so a default checkout would
-      # land on the base branch and `uses: ./` would run the OLD (main) action — the
-      # opposite of self-review. Pin the comment path to the PR merge ref explicitly.
+      # workspace. On pull_request, the default checkout is the PR merge ref, so
+      # `./` resolves to the action code being changed by the PR.
       - uses: actions/checkout@v4
-        with:
-          ref: >-
-            ${{ github.event_name == 'issue_comment'
-                && format('refs/pull/{0}/merge', github.event.issue.number)
-                || github.ref }}
       - uses: ./
         with:
           orcarouter-api-key: ${{ secrets.ORCAROUTER_API_KEY }}

--- a/.github/workflows/self-review.yml
+++ b/.github/workflows/self-review.yml
@@ -1,0 +1,52 @@
+# Review THIS repo's own PRs with the action code in the PR branch.
+#
+# Uses the LOCAL action (`uses: ./`) instead of a published tag, so a PR is
+# reviewed by the version of action.yml/scripts it itself changes — the only way
+# to test action changes end-to-end before moving the release tag.
+#
+# Trigger is `pull_request` (NOT pull_request_target) on purpose: pull_request_target
+# would run the action from the base branch (main), which would test the OLD code,
+# not the PR's. Same-repo PRs (branches pushed straight to this repo) still receive
+# secrets and a write token under `pull_request`, so the review can post + gate.
+#
+# COST: every run spends real, wallet-metered OrcaRouter quota. Requires the
+# `ORCAROUTER_API_KEY` secret on this repo. Fork PRs get no secret (key is empty)
+# and are effectively skipped.
+
+name: Self-review
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    # Auto-run on PR events, or on demand when a maintainer comments
+    # `/orcarouter-review` (lets you re-review without a new push, and gates the
+    # paid run to owner/member/collaborator).
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/orcarouter-review') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    steps:
+      # Required so the local `uses: ./` action definition is present in the
+      # workspace. For pull_request this checks out the PR merge ref, so `./`
+      # resolves to the action code being changed by the PR.
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          orcarouter-api-key: ${{ secrets.ORCAROUTER_API_KEY }}

--- a/.github/workflows/self-review.yml
+++ b/.github/workflows/self-review.yml
@@ -10,8 +10,9 @@
 # secrets and a write token under `pull_request`, so the review can post + gate.
 #
 # COST: every run spends real, wallet-metered OrcaRouter quota. Requires the
-# `ORCAROUTER_API_KEY` secret on this repo. Fork PRs get no secret (key is empty)
-# and are effectively skipped.
+# `ORCAROUTER_API_KEY` secret on this repo. Fork PRs never see that secret, so the
+# job condition below skips them outright (head repo != this repo) — otherwise they
+# would reach the action with an empty key and fail the required check, not "skip".
 
 name: Self-review
 
@@ -37,7 +38,8 @@ jobs:
     # `/orcarouter-review` (lets you re-review without a new push, and gates the
     # paid run to owner/member/collaborator).
     if: |
-      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         startsWith(github.event.comment.body, '/orcarouter-review') &&

--- a/.github/workflows/self-review.yml
+++ b/.github/workflows/self-review.yml
@@ -46,9 +46,17 @@ jobs:
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     steps:
       # Required so the local `uses: ./` action definition is present in the
-      # workspace. For pull_request this checks out the PR merge ref, so `./`
-      # resolves to the action code being changed by the PR.
+      # workspace. For pull_request, github.ref is already the PR merge ref, so `./`
+      # resolves to the action code being changed by the PR. For issue_comment
+      # (/orcarouter-review) the event carries no PR ref, so a default checkout would
+      # land on the base branch and `uses: ./` would run the OLD (main) action — the
+      # opposite of self-review. Pin the comment path to the PR merge ref explicitly.
       - uses: actions/checkout@v4
+        with:
+          ref: >-
+            ${{ github.event_name == 'issue_comment'
+                && format('refs/pull/{0}/merge', github.event.issue.number)
+                || github.ref }}
       - uses: ./
         with:
           orcarouter-api-key: ${{ secrets.ORCAROUTER_API_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -3,20 +3,21 @@
 # Consumers reference this with `uses:` instead of copying the folder; see
 # workflows/orcarouter-code-review.yml for the ~15-line example workflow.
 #
-# Stateful cost-tiered cascade: each PR stores its current tier as an
-# `orca-review:strong` label. A PR with no label runs the cheap tier first; if
-# that pass is clear of `fix-first` (P0/P1) it escalates to the strong tier in
-# the SAME run — so the strong tier always reviews before merge — and records a
-# permanent promotion so later pushes go straight to the strong tier. While the
-# cheap tier still finds `fix-first`, the strong tier is withheld (fix those
-# first — no point paying for it while obvious bugs remain). Findings post as
-# inline PR comments and a severity gate can fail the check to block the merge.
+# Single-tier review (gpt-5.5): one review pass per run. The cheap->strong
+# cascade was retired after testing showed the cheap tier added no value online
+# — it fails closed on large diffs and otherwise just escalates anyway, taxing
+# every PR with latency for no decision. Size-based front routing (small->cheap,
+# large->strong, decided up front) is a planned later optimization and is also
+# single-pass, so this design stays forward-compatible. Findings post as inline
+# PR comments and a severity gate can fail the check to block the merge.
 #
-# Model selection is NOT hardcoded here. The action only DECIDES the tier and
-# emits it as raw facts (x-cr-prev-tier / x-cr-prev-p0p1). OCR can't send custom
-# headers, so an in-job loopback proxy (scripts/fact-proxy.mjs) stamps those
-# facts onto OCR's requests; the workspace router's DSL recipe
-# (recipes/code-review.dsl.yaml) maps them to the concrete cheap/strong model.
+# Model selection is NOT hardcoded here. The action emits raw facts
+# (x-cr-prev-tier / x-cr-prev-p0p1); it injects the strong-tier facts so the
+# router picks the single model. OCR can't send custom headers, so an in-job
+# loopback proxy (scripts/fact-proxy.mjs) stamps those facts onto OCR's
+# requests; the workspace router's DSL recipe (recipes/code-review.dsl.yaml)
+# maps them to the concrete model. The facts and rule shape are preserved so a
+# future size-based front-routing policy can re-diverge without an Action change.
 #
 # Around the cascade: dashboard settings (scripts/settings.mjs, fetched
 # fail-open from the gateway; `settings: "false"` skips the fetch and makes
@@ -724,46 +725,25 @@ runs:
           done
         }
 
-        # Single-run cascade. A promoted PR (tier 1) injects prev-tier=strong, so
-        # the DSL's `promoted` rule keeps it on strong. A tier-0 PR injects the
-        # cheap-tier facts first; if that pass is clear of FIX_FIRST (P0/P1) we
-        # escalate IN THIS SAME RUN by injecting prev-tier=cheap/prev-p0p1=false
-        # (the DSL's `escalate` rule -> strong) — so the strong tier always reviews
-        # before the PR can merge — and record the promotion so later pushes skip
-        # the cheap pass. If the cheap tier still finds FIX_FIRST, hold the strong
-        # tier until those are fixed.
-        # Each tier's result is snapshotted and its outcome written to
-        # $GITHUB_OUTPUT AS SOON as it is known (outputs written before a later
-        # failure still surface), so the per-tier report steps have each tier's
-        # own counts: `cheap_gate` (blocked|pass) doubles as "the cheap tier ran
-        # to a decision", `strong_ran` marks a completed strong pass.
+        # Single review pass per run (gpt-5.5). The cheap->strong cascade was
+        # retired: testing showed the cheap tier added no value online — it fails
+        # closed on large diffs and otherwise just escalates anyway, taxing every
+        # PR with latency for no decision. We inject the strong-tier facts
+        # (prev-tier=strong) so the DSL's `promoted` rule routes gpt-5.5 for every
+        # run, and run exactly one enforced pass (exhaustive extras still allowed
+        # via the 4th arg). PROMOTE/HELD stay false and `cheap_gate` is never
+        # written, so the promotion-label step and the cheap report step no-op and
+        # the Enforce step does a plain single-pass gate. Size-based front routing
+        # (small->cheap, large->strong, decided up front) is a planned later
+        # optimization and is also single-pass, so this shape stays
+        # forward-compatible: the facts and the DSL rule shape are preserved.
         PROMOTE=false
         HELD=false
         PASSES=1
-        if [ "$TIER_STATE" = "1" ]; then
-          run_review "strong tier (promoted)" "strong" "false" true
-          cp "$RESULT" "$RESULT_STRONG"
-          echo "strong_ran=true" >> "$GITHUB_OUTPUT"
-        else
-          run_review "cheap tier" "cheap" "true" false
-          cp "$RESULT" "$RESULT_CHEAP"
-          if node "$GATE" "$RESULT" --has "$FIX_FIRST"; then
-            echo "Cheap tier found $FIX_FIRST — holding the strong tier until those are fixed."
-            echo "cheap_gate=blocked" >> "$GITHUB_OUTPUT"
-            HELD=true
-          else
-            echo "Cheap tier clear of $FIX_FIRST — escalating to the strong tier now."
-            echo "cheap_gate=pass" >> "$GITHUB_OUTPUT"
-            run_review "strong tier (escalation)" "cheap" "false" true
-            cp "$RESULT" "$RESULT_STRONG"
-            echo "strong_ran=true" >> "$GITHUB_OUTPUT"
-            PROMOTE=true
-          fi
-        fi
+        run_review "review (gpt-5.5)" "strong" "false" true
+        cp "$RESULT" "$RESULT_STRONG"
+        echo "strong_ran=true" >> "$GITHUB_OUTPUT"
         echo "promote=$PROMOTE" >> "$GITHUB_OUTPUT"
-        # `held` means the cheap tier withheld the strong review on fix-first
-        # findings; the gate must block so the PR can't merge with an unfixed
-        # P0/P1 that the strong tier never even saw.
         echo "held=$HELD" >> "$GITHUB_OUTPUT"
         # Engine passes behind the FINAL result (the last tier that ran) —
         # >1 only in exhaustive mode; the summary comment notes it.

--- a/recipes/code-review.dsl.yaml
+++ b/recipes/code-review.dsl.yaml
@@ -4,6 +4,12 @@
 # (Dashboard → Routers → code-review → DSL). The Action never names a model; it
 # only injects raw facts as headers and this recipe decides which model runs.
 #
+# MIGRATION — this recipe lives in YOUR OrcaRouter workspace, not in the Action, so
+# bumping the Action version does NOT update it. An install still running an older
+# recipe (e.g. `promoted` -> z-ai/glm-5.1) keeps routing that model until you
+# re-paste the block below. After upgrading the Action, re-paste this into the
+# router DSL to actually pick up the single-tier gpt-5.5 policy.
+#
 # Facts injected by the Action (via the in-job proxy shim):
 #   x-cr-prev-tier : none | cheap | strong   (tier used on the previous pass)
 #   x-cr-prev-p0p1 : true | false            (did the previous pass find a P0/P1)

--- a/recipes/code-review.dsl.yaml
+++ b/recipes/code-review.dsl.yaml
@@ -2,33 +2,38 @@
 #
 # Paste this into the per-workspace router `orcarouter/code-review`
 # (Dashboard → Routers → code-review → DSL). The Action never names a model; it
-# only injects raw facts as headers and this recipe decides cheap vs strong.
+# only injects raw facts as headers and this recipe decides which model runs.
 #
 # Facts injected by the Action (via the in-job proxy shim):
 #   x-cr-prev-tier : none | cheap | strong   (tier used on the previous pass)
 #   x-cr-prev-p0p1 : true | false            (did the previous pass find a P0/P1)
 #
-# Policy (first match wins):
-#   1. promoted    — once the PR reached strong, it stays strong forever
-#                    (strong-found P0/P1 blocks the merge but never demotes).
-#   2. holding     — cheap tier still has P0/P1 outstanding → keep looping cheap.
-#   3. escalate    — cheap tier came back clean → promote to the strong final pass.
-#   default        — fresh PR / no prior state → start on cheap.
+# Single-tier policy: testing showed the cheap->strong cascade added no value
+# online (cheap fails closed on large diffs, otherwise just escalates anyway), so
+# every branch now routes gpt-5.5 — the validated quality bar. The facts are
+# still injected and the rule shape is preserved so a future size-based
+# front-routing policy can re-diverge these branches without an Action change.
+#
+# The `model` in each `use:` below is FREELY CHOOSABLE — swap in any model your
+# OrcaRouter workspace can reach (e.g. openai/gpt-5.5, anthropic/claude-opus-4-8,
+# z-ai/glm-5.1, deepseek/deepseek-v4-pro). gpt-5.5 is our validated default; to
+# re-diverge into a real cost cascade, just give different branches different
+# models (e.g. a cheap model on `holding`, a strong one on `promoted`/`escalate`).
 
 version: 1
 
 rules:
   - id: promoted
     when: 'headers["x-cr-prev-tier"] == "strong"'
-    use: { model: "z-ai/glm-5.1" }
+    use: { model: "openai/gpt-5.5" }
 
   - id: holding
     when: 'headers["x-cr-prev-tier"] == "cheap" && headers["x-cr-prev-p0p1"] == "true"'
-    use: { model: "deepseek/deepseek-v4-pro" }
+    use: { model: "openai/gpt-5.5" }
 
   - id: escalate
     when: 'headers["x-cr-prev-tier"] == "cheap" && headers["x-cr-prev-p0p1"] == "false"'
-    use: { model: "z-ai/glm-5.1" }
+    use: { model: "openai/gpt-5.5" }
 
 default:
-  model: "deepseek/deepseek-v4-pro"
+  model: "openai/gpt-5.5"


### PR DESCRIPTION
## Summary
- Collapse the two-pass cheap→strong cascade to **a single enforced review pass** that injects the strong-tier facts, so the DSL routes one model.
- Point every recipe branch at **`openai/gpt-5.5`** (the validated quality bar) and document that the model in each `use:` is **freely swappable** — re-diverging into a real cost cascade is just a matter of giving branches different models.
- `PROMOTE`/`HELD` stay false and `cheap_gate` is never written, so the promotion-label step and the cheap report step no-op and the Enforce step does a plain single-pass gate. **Exhaustive extra passes are preserved.**

## Why
Testing against real PRs showed the cheap tier added no value online: it fails closed on large diffs, and otherwise just escalates anyway — so every PR paid latency/cost for no decision. The injected facts and DSL rule shape are **kept intact** so a future size-based front-routing policy (small→cheap, large→strong, decided up front) can re-diverge without an Action change.

## Test plan
- [ ] `action.yml` + recipe parse as valid YAML.
- [ ] A PR run performs exactly one review pass and posts findings.
- [ ] Merge gate still blocks on `block-on` severities from the single pass.
- [ ] Exhaustive mode still runs extra passes when enabled.
- [ ] Promotion-label and cheap-report steps are correctly skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)