### PR TITLE
chore: gitignore local research and iteration artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ node_modules/
 .env.*
 *.log
 .DS_Store
+
+# Local research / iteration artifacts. Kept out of the public repo so
+# reviewer transcripts, draft prompts, and week-by-week notes cannot land
+# via an accidental `git add -A`. Anything meant for the repo should live
+# in a tracked, generically-worded file (README, docs/, rules/*.md).
+docs/reports/
+feedbacks/
+rules/*.draft.md


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

Tier: STRONG (final pass) — pass

✅ no blocking findings
<!-- orca-cr-summary:end -->

## Summary
Add explicit `.gitignore` entries for three folders / file patterns that live locally next to the action for convenience while iterating but must not land in this public repo via an accidental `git add -A`:

- `docs/reports/` — local weekly notes
- `feedbacks/` — local reviewer transcripts and adjudication scratch
- `rules/*.draft.md` — WIP severity / conventions rules

Anything intended to ship should live in a tracked, generically-worded file (`README.md`, `docs/**`, `rules/*.md`, etc.).

## Test plan
- [x] `git check-ignore -v` confirms all three paths resolve to the new rules
- [x] No previously-tracked file becomes ignored (only untracked local paths are affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)