### PR TITLE
fix: stop --pricing from being mistaken for the usage file

### DIFF
--- a/scripts/usage-summary.mjs
+++ b/scripts/usage-summary.mjs
@@ -29,13 +29,28 @@ import fs from "node:fs";
 
 const USD_PER_1M_AT_RATIO_1 = 2.0;
 
+// One pass, because a flag's VALUE is not a positional argument. --pricing
+// takes a path, and a path does not start with "--", so scanning separately
+// for "the first argv entry that isn't a flag" picks up the price list as the
+// usage file whenever --pricing comes first. That failure is silent rather
+// than loud: a price list is itself valid JSON, so it parses as a single
+// metering row with no token fields and reports a run that cost nothing.
+// Advancing the index past a flag's value keeps both argument orders working.
 const argv = process.argv.slice(2);
-const file = argv.find((a) => !a.startsWith("--"));
+let file = null;
 let pricingPath = null;
 let asJson = false;
 for (let i = 0; i < argv.length; i += 1) {
-  if (argv[i] === "--pricing") pricingPath = argv[i + 1];
-  else if (argv[i] === "--json") asJson = true;
+  if (argv[i] === "--pricing") {
+    // Only consume the next entry when it is actually a value. A trailing
+    // --pricing, or one followed by another flag, must not swallow that flag.
+    const next = argv[i + 1];
+    if (next !== undefined && !next.startsWith("--")) {
+      pricingPath = next;
+      i += 1;
+    }
+  } else if (argv[i] === "--json") asJson = true;
+  else if (!argv[i].startsWith("--") && file === null) file = argv[i];
 }
 if (!file) {
   console.error("usage: node usage-summary.mjs <usage.jsonl> [--pricing pricing.json] [--json]");

--- a/scripts/usage-summary.test.mjs
+++ b/scripts/usage-summary.test.mjs
@@ -59,8 +59,8 @@ function run(args) {
   return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
 }
 
-// The flag order matters: the file is the first argv entry not starting with
-// "--", so the usage file must precede --pricing. That is the documented order.
+// Most cases below use the documented order (usage file first); the
+// "argument order" block pins that the reverse order works too.
 function runJson(args) {
   const r = run([...args, "--json"]);
   assert.equal(r.status, 0, r.stderr);
@@ -156,6 +156,59 @@ describe("best-effort input handling", () => {
     const out = JSON.parse(r.stdout);
     assert.equal(out.prompt_tokens, 1000, "tokens are still reported");
     assert.equal(out.usd, null, "but nothing is priced");
+  });
+});
+
+describe("argument order", () => {
+  // A flag's value is not a positional argument. --pricing takes a path, and a
+  // path does not start with "--", so a "first non-flag argv entry" scan used
+  // to pick the price list as the usage file when the flag came first. It
+  // failed silently: a price list is valid JSON, so it parsed as one metering
+  // row with no token fields and reported a run that cost nothing.
+  test("--pricing before the usage file does not steal it", () => {
+    const usage = writeUsage([{ model: "m", prompt: 1_000_000 }]);
+    const pricing = writePricing([{ model_name: "m", model_ratio: 1 }]);
+    const r = run(["--pricing", pricing, usage, "--json"]);
+    assert.equal(r.status, 0, r.stderr);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.prompt_tokens, 1_000_000, "the usage file must be read, not the price list");
+    assert.equal(out.usd, 2, "and the price list must still be applied");
+  });
+
+  test("both orders produce the same result", () => {
+    const usage = writeUsage([{ model: "m", prompt: 500_000, completion: 1000 }]);
+    const pricing = writePricing([{ model_name: "m", model_ratio: 1 }]);
+    const flagFirst = JSON.parse(run(["--pricing", pricing, usage, "--json"]).stdout);
+    const fileFirst = JSON.parse(run([usage, "--pricing", pricing, "--json"]).stdout);
+    assert.deepEqual(flagFirst, fileFirst);
+  });
+
+  test("the first positional wins; a stray extra one does not override it", () => {
+    const usage = writeUsage([{ model: "m", prompt: 10 }]);
+    const other = writeUsage([{ model: "m", prompt: 999 }]);
+    const out = JSON.parse(run([usage, other, "--json"]).stdout);
+    assert.equal(out.prompt_tokens, 10);
+  });
+
+  test("--json is recognized wherever it appears", () => {
+    const usage = writeUsage([{ model: "m", prompt: 7 }]);
+    const out = JSON.parse(run(["--json", usage]).stdout);
+    assert.equal(out.prompt_tokens, 7);
+  });
+
+  test("a valueless --pricing does not swallow the flag after it", () => {
+    const usage = writeUsage([{ model: "m", prompt: 7 }]);
+    const r = run([usage, "--pricing", "--json"]);
+    assert.equal(r.status, 0, r.stderr);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.prompt_tokens, 7, "--json must still be honored");
+    assert.equal(out.usd, null, "no price list was supplied");
+  });
+
+  test("a trailing --pricing with nothing after it is harmless", () => {
+    const usage = writeUsage([{ model: "m", prompt: 7 }]);
+    const r = run([usage, "--pricing"]);
+    assert.equal(r.status, 0, r.stderr);
   });
 });
 


### PR DESCRIPTION
## The bug

`usage-summary.mjs` picked its input file with a separate scan for "the first argv entry that does not start with `--`":

```js
const file = argv.find((a) => !a.startsWith("--"));
```

A flag's **value** is not a positional argument, though. `--pricing` takes a path, and a path does not start with `--`, so putting the flag first made the price list get read as the metering file.

## Why it mattered

The failure was silent rather than loud. A price list is itself valid JSON, so it parsed as a single metering row with no token fields:

```
node usage-summary.mjs --pricing pricing.json usage.jsonl --json
  -> calls: 1, prompt_tokens: 0
```

Exit 0, no warning, not even a malformed-line count — and the real usage file never read. For a script whose entire purpose is comparing model costs, a plausible-looking `$0.00` is the worst possible output: it doesn't look like an error, it looks like a cheap model.

## Scope

**Not reachable from `action.yml`**, which calls `node "$USAGE_SUMMARY" "$USAGE_FILE"` — file first, and no `--pricing` at all. This only bit manual cost-comparison runs, which is exactly when `--pricing` gets used.

## The fix

Fold the two scans into one pass that advances past a flag's value. The value is only consumed when it actually is one, so a trailing `--pricing` or one followed by another flag does not swallow it.

## Tests

6 added (27 -> 33 in this file):

- `--pricing` before the usage file no longer steals it, and the price list is still applied
- both argument orders produce identical output
- the first positional wins; a stray extra one does not override it
- `--json` is recognized wherever it appears
- a valueless `--pricing` does not swallow the flag after it
- a trailing `--pricing` with nothing after it is harmless

🤖 Generated with [Claude Code](https://claude.com/claude-code)
