### PR TITLE
feat: one-command installers — npx CLI + Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "orca",
+  "owner": {
+    "name": "Continuum-AI-Corp",
+    "url": "https://github.com/Continuum-AI-Corp"
+  },
+  "metadata": {
+    "description": "Skills for OrcaRouter products.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "orca-code-review",
+      "source": "./",
+      "description": "Set up, reconfigure, troubleshoot, and remove OrcaCode Review — AI pull-request review powered by OrcaRouter — in any GitHub repository.",
+      "category": "code-review",
+      "keywords": ["code-review", "github-actions", "ci", "pull-request"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "orca-code-review",
+  "description": "Set up, reconfigure, troubleshoot, and remove OrcaCode Review — AI pull-request review powered by OrcaRouter — in any GitHub repository.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Continuum-AI-Corp",
+    "url": "https://github.com/Continuum-AI-Corp"
+  },
+  "homepage": "https://www.orcarouter.ai/code-review",
+  "repository": "https://github.com/Continuum-AI-Corp/orca-code-review",
+  "license": "MIT",
+  "keywords": [
+    "code-review",
+    "github-actions",
+    "ci",
+    "pull-request",
+    "orcarouter"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+*.tgz
 .env
 .env.*
 *.log

--- a/README.md
+++ b/README.md
@@ -33,6 +33,72 @@ Every PR starts with a fast, low-cost model. Once clear of P0/P1 issues, OrcaCod
 
 ---
 
+## One-command install
+
+Either installer writes the workflow, guides you through the API key, and sets up the merge gate.
+
+**Terminal — no install required:**
+
+```bash
+npx orcacode-review
+```
+
+**Claude Code — as a plugin:**
+
+```text
+/plugin marketplace add Continuum-AI-Corp/orca-code-review
+/plugin install orca-code-review
+```
+
+Then ask: *"set up OrcaCode Review in this repo"*. The skill also handles reconfiguring, troubleshooting, and uninstalling.
+
+The CLI has the same lifecycle commands:
+
+```bash
+npx orcacode-review init          # write the workflow
+npx orcacode-review reconfigure   # change blocking rules, diff limits, where config lives
+npx orcacode-review doctor        # diagnose reviews that don't run or don't post
+npx orcacode-review uninstall     # remove it (drops the merge gate first)
+```
+
+Prefer to wire it by hand? The manual steps are below.
+
+### Use it from any agent
+
+The setup skill installs into **36 agent platforms** — the same catalog the [OrcaDub MCP server](https://github.com/Continuum-AI-Corp/orcadub-mcp-server) uses, so IDs and paths match across Orca products.
+
+```bash
+npx orcacode-review skill list      # all 36, with the ones detected here marked
+npx orcacode-review skill install   # pick from a checkbox list; detected agents pre-checked
+```
+
+Detected platforms are pre-selected. For unattended or agent-driven setup, name them:
+
+```bash
+npx orcacode-review skill install --platform claude --platform codex --scope project --yes
+npx orcacode-review skill install --platform cursor --scope global --yes
+```
+
+Claude Code, Cursor, Codex, OpenCode, Windsurf, Cline, RooCode, Continue, GitHub Copilot, Gemini CLI, Amazon Q Developer, Qwen Code, Kilo Code, Auggie, Kimi Code, Kiro, Lingma, Junie, CodeBuddy Code, CoStrict, Crush, Factory Droid, iFlow, Pi, Qoder, Antigravity, Antigravity 2.0, Bob Shell, ForgeCode, Trae, Trae CN, ZCode, MimoCode, Hermes, OpenClaw, Command Code.
+
+An existing identical skill is left unchanged; an existing **different** one is preserved unless you pass `--force`. Use `--json` for structured output and `NO_COLOR` for plain text.
+
+### Language
+
+The CLI speaks **English and Simplified Chinese**, picked from your locale (`LC_ALL` / `LC_MESSAGES` / `LANG`). Override it per run, or pin it for good:
+
+```bash
+npx orcacode-review --lang zh          # 中文界面
+npx orcacode-review --lang en          # English
+export ORCACODE_LANG=zh                # 固定下来
+```
+
+Guided flows open with a language screen when `--lang` is not given. Add `--no-banner` to skip the wordmark.
+
+Only prose is translated — flags, platform IDs, workflow inputs, and shell commands stay verbatim, because you still have to type them.
+
+---
+
 ## Quick Start
 
 ### 1. Enable OrcaCode Review

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,3 +39,76 @@ pre-release dogfooding, pin an immutable commit SHA (as OrcaRouter-O2's own
 Publish/refresh the GitHub Marketplace listing from the same merged commit as
 a verified publisher; the listing's default install snippet must match the
 README quickstart (including `@v1` once moved).
+
+## Installers
+
+Two one-command installers ship from this repo, and both generate a workflow
+that pins `@v1`. **Release them only after the `v1` tag has been moved** — an
+installer that writes `@v1` against a stale tag hands every new user the dead
+Settings/Analytics tabs described above, on their very first run.
+
+### npm — `npx orcacode-review`
+
+Package name is `orcacode-review` (one word, matching the product name and the
+`/orcacode-review` PR command); the repo and action stay `orca-code-review`.
+
+```
+npm publish --access public          # from the merged commit, after `npm test`
+npx orcacode-review@latest doctor    # smoke-test the published tarball
+```
+
+`files` in `package.json` ships only `bin/` and `skills/` — the action itself is
+consumed from GitHub, never from npm. The CLI has **no dependencies**; keep it
+that way, since `npx` downloads the whole tree before running anything.
+
+#### The platform catalog is shared with orcadub
+
+`bin/platforms.mjs` is a port of `internal/skill_installer.go` in
+[orcadub-mcp-server](https://github.com/Continuum-AI-Corp/orcadub-mcp-server).
+The IDs, display names, roots, and detection rules must stay identical — a user
+who runs both installers should not have to learn two names for the same
+editor, and `--platform codex` must mean the same directory in both.
+
+When either side adds a platform, add it to the other and bump the count in
+three places: `scripts/platforms.test.mjs` (the count assertion is the tripwire),
+the README platform list, and the orcadub README.
+
+#### Adding a user-facing string
+
+`bin/i18n.mjs` holds both languages. `scripts/i18n.test.mjs` fails the build if
+the two tables diverge — a missing Chinese key, a key only Chinese has, or a
+parameterized string whose two versions take different argument counts (which
+would silently drop a branch name or a count from the Chinese output).
+
+Translate prose only. Flags, platform IDs, workflow inputs, severity codes,
+paths, and shell commands stay verbatim in both languages: a reader of the
+Chinese output still has to type `--platform codex` and grep for `block-on`.
+A test asserts that the literals present in the English table survive into the
+Chinese one.
+
+Detection rules carry the load here, and getting one wrong is silent. Two
+standing rules, both already encoded as tests:
+
+- Never detect on a root that most repos have anyway (`.github`, `.`) — it
+  preselects a platform for everyone.
+- Never detect on an executable whose name collides with a stock system binary
+  (Command Code's `cmd` on Windows).
+
+### Claude Code plugin
+
+`.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` make this repo
+its own plugin marketplace:
+
+```
+/plugin marketplace add Continuum-AI-Corp/orca-code-review
+/plugin install orca-code-review
+```
+
+The plugin is served from the repo's **default branch**, not from a tag — a
+change to `skills/` reaches users as soon as it lands on `main`, with no release
+step. Treat `skills/setup-orca-code-review/` as shipped surface on merge.
+
+Three versions have to move together on a feature release: `package.json`,
+`.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`
+(`metadata.version`). Nothing enforces this — a mismatch shows up as a plugin
+that reports the wrong version in `/plugin`.

--- a/bin/banner.mjs
+++ b/bin/banner.mjs
@@ -1,0 +1,81 @@
+// The ORCA CODE REVIEW wordmark, in the shape orcadub uses for ORCADUB:
+// block glyphs, horizontally scaled so the letters read square in a terminal
+// (cells are about twice as tall as they are wide), with a blue-to-cyan
+// gradient down the block.
+//
+// Two lines rather than one. "ORCA CODE REVIEW" on a single line is 16 glyph
+// slots — about 150 columns at this scale, which is wider than any default
+// terminal. Split as ORCA CODE / REVIEW it fits in 76.
+//
+// Glyphs are variable width: V and W need five columns to be legible, I needs
+// three. Only the rows within one glyph have to agree.
+
+const SCALE = 2; // horizontal only — vertical scaling would make it 10 rows tall
+const GAP = 1; // columns between glyphs, before scaling is applied
+const BLUE = "[94m";
+const CYAN = "[96m";
+const RESET = "[0m";
+
+const GLYPHS = {
+  O: ["████", "█  █", "█  █", "█  █", "████"],
+  R: ["███ ", "█  █", "███ ", "█ █ ", "█  █"],
+  C: ["████", "█   ", "█   ", "█   ", "████"],
+  A: [" ██ ", "█  █", "████", "█  █", "█  █"],
+  D: ["███ ", "█  █", "█  █", "█  █", "███ "],
+  E: ["████", "█   ", "███ ", "█   ", "████"],
+  V: ["█   █", "█   █", "█   █", " █ █ ", "  █  "],
+  I: ["███", " █ ", " █ ", " █ ", "███"],
+  W: ["█   █", "█   █", "█ █ █", "██ ██", "█   █"],
+  " ": ["  ", "  ", "  ", "  ", "  "],
+};
+
+const ROWS = 5;
+const LINES = ["ORCA CODE", "REVIEW"];
+
+function renderLine(word) {
+  const rows = [];
+  for (let row = 0; row < ROWS; row++) {
+    let out = "";
+    for (const [index, letter] of [...word].entries()) {
+      if (index > 0) out += " ".repeat(GAP);
+      for (const cell of GLYPHS[letter][row]) out += cell.repeat(SCALE);
+    }
+    rows.push(out);
+  }
+  return rows;
+}
+
+/** The wordmark as an array of lines. `color` adds the gradient. */
+export function bannerRows(color = true) {
+  const blocks = LINES.map(renderLine);
+  const width = Math.max(...blocks.map((b) => b[0].length));
+  const total = blocks.reduce((n, b) => n + b.length, 0);
+
+  const rows = [];
+  for (const block of blocks) {
+    // Center the shorter line under the longer one, or the wordmark reads as
+    // two unrelated words that happen to be stacked.
+    const pad = " ".repeat(Math.floor((width - block[0].length) / 2));
+    for (const row of block) {
+      const line = pad + row;
+      rows.push(color ? `${rows.length < total / 2 ? BLUE : CYAN}${line}${RESET}` : line);
+    }
+  }
+  return rows;
+}
+
+export function bannerWidth() {
+  return Math.max(...LINES.map((w) => renderLine(w)[0].length));
+}
+
+/**
+ * Prints the wordmark, or a one-line title when the terminal is too narrow.
+ * A wrapped wordmark is worse than no wordmark — it reads as corruption.
+ */
+export function renderBanner(write, { color = true, columns = process.stdout.columns } = {}) {
+  if (columns && columns < bannerWidth()) {
+    write(`${color ? BLUE : ""}Orca Code Review${color ? RESET : ""}\n`);
+    return;
+  }
+  for (const row of bannerRows(color)) write(`${row}\n`);
+}

--- a/bin/i18n.mjs
+++ b/bin/i18n.mjs
@@ -1,0 +1,482 @@
+// Simplified Chinese / English strings for the installer, matching the
+// zh|en pair orcadub's Skill installer ships.
+//
+// Two rules hold this together:
+//
+//   1. English is the fallback for any key a translation misses, so a gap
+//      shows up as an English line rather than a blank or a raw key.
+//   2. Only prose is translated. Flag names, platform IDs, workflow inputs,
+//      severity codes, file paths, and shell commands stay verbatim in both
+//      languages — a user who reads the Chinese output still has to type
+//      `--platform codex` and grep for `block-on`, and translating those would
+//      make the output impossible to act on.
+
+export const LANGUAGES = Object.freeze(["en", "zh"]);
+
+export function parseLanguage(raw) {
+  const value = String(raw ?? "").trim().toLowerCase();
+  if (LANGUAGES.includes(value)) return value;
+  throw new Error(`unknown language "${raw}" (use zh or en)`);
+}
+
+/** Picks a default from the POSIX locale variables, in the usual precedence. */
+export function detectLanguage(env = process.env) {
+  if (env.ORCACODE_LANG) {
+    try { return parseLanguage(env.ORCACODE_LANG); } catch { /* fall through to the locale */ }
+  }
+  const raw = env.LC_ALL || env.LC_MESSAGES || env.LANG || "";
+  const locale = raw.split(".")[0].replaceAll("_", "-").toLowerCase();
+  return ["zh", "zh-cn", "zh-sg", "zh-hans", "zh-hans-cn"].includes(locale) ? "zh" : "en";
+}
+
+const EN = {
+  lang: { question: "Language / 语言", en: "English", zh: "简体中文" },
+
+  common: {
+    recommended: "(recommended)",
+    detected: "detected",
+    chooseRange: (n, d) => `  choose 1-${n} [${d}] `,
+    enterNumber: (n) => `Enter a number between 1 and ${n}.`,
+    multiHint: "e.g. 1,3 or 1-4 · a = all · Enter = keep the checked set",
+    selectPrompt: "  select ",
+    nothingSelected: "Nothing selected. Pick at least one, or press Ctrl-C to abort.",
+    nonTTY: (what) => `Cannot ask about ${what} — stdin is not a terminal.`,
+    nonTTYHint: "Re-run with --yes to accept the recommended defaults, or pass the flags explicitly (--help).",
+    notGitRepo: "Not inside a git repository.",
+    notGitRepoHint: "cd into your repo and run this again.",
+    unknownOption: (a) => `Unknown option: ${a}`,
+    unknownOptionHint: "Run with --help for usage.",
+    unknownCommand: (c) => `Unknown command: ${c}`,
+    unknownLanguage: (l) => `Unknown language "${l}".`,
+    unknownLanguageHint: "Use --lang zh or --lang en.",
+    missingPlatformValue: "--platform needs a value.",
+    aborted: "Aborted. Nothing was written.",
+    abortedRemoval: "Aborted. Nothing was removed.",
+  },
+
+  menu: {
+    question: "OrcaCode Review — what do you want to do?",
+    alreadyInstalled: " (already installed here)",
+    install: "Install",
+    reconfigure: "Reconfigure",
+    doctor: "Doctor — diagnose a problem",
+    skill: (n) => `Install the agent skill (${n} platforms)`,
+    uninstall: "Uninstall",
+  },
+
+  config: {
+    settingsQ: "Where should review settings live?",
+    settingsDashboard: "OrcaRouter dashboard",
+    settingsDashboardDetail:
+      "Change models, review mode, rubric, and severity rules from the console — no workflow edit.",
+    settingsFile: "This workflow file",
+    settingsFileDetail:
+      "Skips the dashboard fetch. The YAML is authoritative; nothing server-side can override it.",
+
+    blockQ: "Which findings should block the merge?",
+    blockBoth: "P0 and P1",
+    blockBothDetail: "The default contract: critical and high severity fail the check.",
+    blockP0: "P0 only",
+    blockP0Detail: "Only critical issues block. P1 still posts inline.",
+    blockNone: "Nothing — comment only",
+    blockNoneDetail: "The check always passes. Good for a trial period.",
+
+    oversizedQ: "What should happen when a PR's diff is too large to review?",
+    oversizedFail: "Fail the check",
+    oversizedFailDetail: "A diff padded past the size limits cannot slip past a required merge gate.",
+    oversizedPass: "Pass with a notice",
+    oversizedPassDetail: "The skip notice posts and the check stays green.",
+
+    publicWarning: (url) =>
+      "This repo is public. The workflow runs on pull_request_target with your\n" +
+      "  OrcaRouter secret, which bypasses GitHub's fork-approval gate — so a stranger\n" +
+      `  opening a PR can spend from your wallet. Set a budget + alert at ${url}.`,
+    authorsQ: "Who gets an automatic review?",
+    authorsKnown: "Known contributors only",
+    authorsKnownDetail: "Everyone else can still be reviewed on demand via /orcacode-review.",
+    authorsAll: "Everyone",
+    authorsAllDetail: "Any PR from anyone triggers a paid review.",
+  },
+
+  init: {
+    title: "OrcaCode Review — install",
+    repo: (name) => `  repo      ${name}`,
+    repoUnknown: "(unknown — no GitHub remote detected)",
+    workflow: (p) => `  workflow  ${p}`,
+    exists: "A workflow already exists at that path.",
+    reconfigureInstead: "Reconfigure it instead?",
+    unchangedHint: "Nothing changed. Re-run with --force to overwrite.",
+    preview: "Workflow to write:",
+    writeConfirm: (p) => `Write ${p}?`,
+    wrote: (p) => `Wrote ${p}`,
+    remaining: "Remaining steps",
+    step1: (url) => `  1. Enable the app: ${url} → Apps → OrcaCode Review`,
+    step1Note: "     Reviews do not run until it is enabled.",
+    step2: "  2. Commit on a branch and open a PR —",
+    step2Note:
+      "     pull_request_target reads the workflow from the base branch, so review\n" +
+      "     only starts once this file is on your default branch.",
+    step3: "  3. Make the gate real: Settings → Branches / Rulesets → Require status checks",
+    step3Note: (check) => `     and add the ${check} check. A red check blocks nothing until it is required.`,
+    diagnoseHint: "  Diagnose anytime with: npx orcacode-review doctor",
+  },
+
+  reconfigure: {
+    title: "OrcaCode Review — reconfigure",
+    missing: (p) => `No workflow at ${p}.`,
+    missingHint: "Run `npx orcacode-review init` first.",
+    dashboardOwns: "This install lets the OrcaRouter dashboard own most settings.",
+    dashboardOwnsDetail: (url) =>
+      "  Review mode, models, exhaustive mode, quiet mode, and the rubric are not in\n" +
+      `  this file — change them at ${url} → Apps → OrcaCode Review.\n` +
+      "  An input written here only wins when it differs from its documented default.",
+    noChanges: "No changes — the workflow already matches those answers.",
+    changes: "Changes",
+    applyConfirm: (p) => `Apply to ${p}?`,
+    updated: (p) => `Updated ${p}`,
+    commitHint: "Commit and push. The new settings apply on the next push to any open PR.",
+  },
+
+  doctor: {
+    title: "OrcaCode Review — doctor",
+    repo: (name) => `  repo ${name}`,
+    repoUnknown: "(unknown)",
+    workflowExists: (p) => `${p} exists`,
+    workflowMissing: (p) => `${p} is missing`,
+    workflowMissingFix: "Run: npx orcacode-review init",
+    onBase: (b) => `Present on origin/${b}`,
+    notOnBase: (b) => `Not on origin/${b} yet`,
+    notOnBaseFix:
+      "pull_request_target reads the workflow from the BASE branch. Merge it before expecting runs.",
+    noGh: "GitHub CLI unavailable or not authenticated — skipping secret, run, and gate checks.",
+    noGhHint: "  Install from https://cli.github.com and run `gh auth login` for the full report.",
+    secretSet: (s) => `Repository secret ${s} is set`,
+    secretMissing: (s) => `Repository secret ${s} not found`,
+    secretMissingFix: (s, url) => `Run: gh secret set ${s}   (key from ${url})`,
+    runsUnreadable: "Could not list workflow runs (the workflow may never have run).",
+    noRuns: "No runs recorded for this workflow",
+    noRunsFix:
+      "Common causes: the app is off in the dashboard, auto_review is off, the PR is a draft\n" +
+      "  under trigger=ready_for_review, or the author is outside auto-review-authors.",
+    recentRuns: (n) => `${n} recent run(s):`,
+    inspectFailure: "Inspect a failure with: gh run view <run-id> --log-failed",
+    gateRequired: (b) => `The "review" check is required on ${b}`,
+    gateMissing: (b) => `The "review" check is NOT required on ${b}`,
+    gateMissingFix:
+      "Findings post, but nothing is blocked. Settings → Branches / Rulesets → Require status checks.",
+    noProtection: (b) => `No branch protection readable on ${b} — merges are not gated.`,
+    clean: "No problems found.",
+    problems: (n) => `${n} problem(s) found — see the fixes above.`,
+    problemsHint:
+      "  Full symptom → cause → fix table: skills/setup-orca-code-review/references/troubleshooting.md",
+  },
+
+  uninstall: {
+    title: "OrcaCode Review — uninstall",
+    nothing: (p) => `Nothing to remove — no ${p}.`,
+    gateFirst:
+      'Drop the required "review" check FIRST.\n' +
+      "  A required check whose workflow no longer exists never reports, and every PR\n" +
+      "  blocks forever with no way to clear it.",
+    gateWhere: (repo, branch) => `  Settings → Branches / Rulesets on ${repo} (${branch})`,
+    deleteConfirm: (p) => `Delete ${p} now?`,
+    removed: (p) => `Removed ${p}`,
+    keepSecret: (s) => `  • The ${s} secret is harmless to keep, and worth keeping if you may reinstall.`,
+    disableApp: (url) => `  • Turn the app off at ${url} → Apps → OrcaCode Review to stop any billing.`,
+    keepComments: "  • Existing review comments are left in place — they are part of the PR history.",
+  },
+
+  skill: {
+    missingBundle: "The bundled skill is missing from this package.",
+    missingBundleHint: "Reinstall with: npx orcacode-review@latest skill",
+    scopeQ: "Where should the skill be installed?",
+    scopeProject: "This project",
+    scopeProjectDetail: "Committed with the repo — everyone who clones it gets the skill.",
+    scopeGlobal: "My user account",
+    scopeGlobalDetail: "Available in every project on this machine.",
+    unknownScope: (s) => `Unknown scope "${s}".`,
+    unknownScopeHint: "Use --scope project or --scope global.",
+    unknownPlatform: (id) => `Unknown platform "${id}".`,
+    unknownPlatformHint: "List them with: orcacode-review skill list",
+    noneDetected: "No agent platform detected here, and none was named.",
+    noneDetectedHint:
+      "Pass one explicitly, e.g. --platform claude --platform codex (`skill list` shows all 36).",
+    platformQ: "Which agents should get the skill?",
+    platformCount: (n) => ` (${n} detected)`,
+    statusUpdated: "(updated)",
+    statusUnchanged: "(already current)",
+    statusConflict: "(left alone — a different version is already there)",
+    forceHint: "Re-run with --force to overwrite the differing copies.",
+    askAgent: 'Ask your agent: "set up OrcaCode Review in this repo".',
+    pluginHint: "  For Claude Code, the plugin keeps itself updated instead:",
+    listTitle: (n) => `${n} supported platforms`,
+    listColumns: "  (project root / global root)",
+    listLegend: "  ● = detected here.  Install with: orcacode-review skill install --platform <id>",
+  },
+
+  secret: {
+    title: (s) => `Repository secret: ${s}`,
+    createHint: (url) => `  Create or copy a key at ${url}`,
+    alreadySet: (s) => `${s} is already set.`,
+    setNow: "Set it now with the GitHub CLI?",
+    wasSet: (s) => `${s} set.`,
+    ghFailed: "gh could not set the secret. Add it in the browser instead:",
+    addManually: (s) => `  Add a secret named ${s} at:`,
+    manualPath: "your repo → Settings → Secrets and variables → Actions → New repository secret",
+  },
+
+  usage: {
+    tagline: "installer for OrcaCode Review (AI PR review by OrcaRouter)",
+    usage: "Usage",
+    commands: "Commands",
+    options: "Options",
+    examples: "Examples",
+    docs: "Docs",
+    cmdInit: "Write .github/workflows/orca-code-review.yml (default)",
+    cmdReconfigure: "Change the inputs in an existing workflow",
+    cmdDoctor: "Diagnose an install that is not working",
+    cmdUninstall: "Remove the workflow",
+    cmdSkillInstall: (n) => `Install the agent skill (${n} platforms)`,
+    cmdSkillList: "List the supported platforms and which are detected here",
+    optYes: "Accept the recommended defaults; never prompt",
+    optForce: "Overwrite without asking",
+    optJson: "Machine-readable output (skill install / skill list)",
+    optLang: "Interface language: zh | en (default: from your locale)",
+    optNoBanner: "Skip the wordmark",
+    optScope: "For `skill`: project | global",
+    optPlatform: "For `skill`: repeatable; omit to pick interactively",
+    optHelp: "Show this",
+    optVersion: "Show the version",
+  },
+};
+
+const ZH = {
+  lang: { question: "Language / 语言", en: "English", zh: "简体中文" },
+
+  common: {
+    recommended: "（推荐）",
+    detected: "已检测",
+    chooseRange: (n, d) => `  请输入 1-${n} [${d}] `,
+    enterNumber: (n) => `请输入 1 到 ${n} 之间的数字。`,
+    multiHint: "例如 1,3 或 1-4 · a = 全选 · 直接回车 = 保持已勾选项",
+    selectPrompt: "  选择 ",
+    nothingSelected: "未选择任何平台。请至少选一个，或按 Ctrl-C 退出。",
+    nonTTY: (what) => `无法询问「${what}」—— 标准输入不是终端。`,
+    nonTTYHint: "加 --yes 使用推荐默认值，或直接用命令行参数指定（见 --help）。",
+    notGitRepo: "当前目录不是 git 仓库。",
+    notGitRepoHint: "先 cd 进你的仓库再运行。",
+    unknownOption: (a) => `未知参数：${a}`,
+    unknownOptionHint: "用 --help 查看用法。",
+    unknownCommand: (c) => `未知命令：${c}`,
+    unknownLanguage: (l) => `未知语言「${l}」。`,
+    unknownLanguageHint: "请用 --lang zh 或 --lang en。",
+    missingPlatformValue: "--platform 需要一个值。",
+    aborted: "已取消，未写入任何内容。",
+    abortedRemoval: "已取消，未删除任何内容。",
+  },
+
+  menu: {
+    question: "OrcaCode Review —— 你想做什么？",
+    alreadyInstalled: "（此仓库已安装）",
+    install: "安装",
+    reconfigure: "修改配置",
+    doctor: "体检 —— 排查问题",
+    skill: (n) => `安装 Agent Skill（${n} 个平台）`,
+    uninstall: "卸载",
+  },
+
+  config: {
+    settingsQ: "评审配置放在哪里？",
+    settingsDashboard: "OrcaRouter 控制台",
+    settingsDashboardDetail: "模型、评审模式、评分规则、严重级别都在控制台改，不用动 workflow。",
+    settingsFile: "当前 workflow 文件",
+    settingsFileDetail: "跳过控制台拉取。以 YAML 为准，服务端任何配置都无法覆盖。",
+
+    blockQ: "哪些问题要拦住合并？",
+    blockBoth: "P0 和 P1",
+    blockBothDetail: "默认约定：严重和高危问题会让检查失败。",
+    blockP0: "只拦 P0",
+    blockP0Detail: "只有严重问题拦截，P1 仍然会评论在代码行上。",
+    blockNone: "都不拦 —— 只评论",
+    blockNoneDetail: "检查永远通过。适合试用期。",
+
+    oversizedQ: "PR 的 diff 大到无法评审时怎么办？",
+    oversizedFail: "让检查失败",
+    oversizedFailDetail: "把 diff 撑到超过体积上限，也没法绕过必需的合并门禁。",
+    oversizedPass: "通过，只发提示",
+    oversizedPassDetail: "发一条跳过说明，检查保持绿色。",
+
+    publicWarning: (url) =>
+      "这是公开仓库。workflow 跑在 pull_request_target 上并带着你的 OrcaRouter\n" +
+      "  密钥，会绕过 GitHub 的 fork 审批门禁 —— 陌生人开个 PR 就能花你的钱。\n" +
+      `  请在 ${url} 设置预算上限和告警。`,
+    authorsQ: "谁的 PR 会被自动评审？",
+    authorsKnown: "仅限已知贡献者",
+    authorsKnownDetail: "其他人仍可由维护者用 /orcacode-review 手动触发评审。",
+    authorsAll: "所有人",
+    authorsAllDetail: "任何人开 PR 都会触发一次付费评审。",
+  },
+
+  init: {
+    title: "OrcaCode Review —— 安装",
+    repo: (name) => `  仓库      ${name}`,
+    repoUnknown: "（未知 —— 没检测到 GitHub remote）",
+    workflow: (p) => `  workflow  ${p}`,
+    exists: "该路径下已存在 workflow。",
+    reconfigureInstead: "改为修改现有配置？",
+    unchangedHint: "未做任何改动。要覆盖请加 --force 重新运行。",
+    preview: "将要写入的 workflow：",
+    writeConfirm: (p) => `写入 ${p}？`,
+    wrote: (p) => `已写入 ${p}`,
+    remaining: "接下来还要做",
+    step1: (url) => `  1. 启用应用：${url} → Apps → OrcaCode Review`,
+    step1Note: "     不启用的话评审不会运行。",
+    step2: "  2. 在分支上提交并开一个 PR ——",
+    step2Note:
+      "     pull_request_target 从目标分支读取 workflow，所以只有这个文件进了\n" +
+      "     默认分支，评审才会开始跑。",
+    step3: "  3. 让门禁真正生效：Settings → Branches / Rulesets → Require status checks",
+    step3Note: (check) => `     把 ${check} 检查设为必需。检查变红本身拦不住任何东西。`,
+    diagnoseHint: "  随时体检：npx orcacode-review doctor",
+  },
+
+  reconfigure: {
+    title: "OrcaCode Review —— 修改配置",
+    missing: (p) => `找不到 ${p}。`,
+    missingHint: "先运行 `npx orcacode-review init`。",
+    dashboardOwns: "这个安装把大部分配置交给了 OrcaRouter 控制台。",
+    dashboardOwnsDetail: (url) =>
+      "  评审模式、模型、穷尽模式、静默模式和评分规则都不在这个文件里 ——\n" +
+      `  去 ${url} → Apps → OrcaCode Review 改。\n` +
+      "  写在这里的 input 只有在与文档默认值不同时才会生效。",
+    noChanges: "没有变化 —— workflow 和你的选择已经一致。",
+    changes: "变更",
+    applyConfirm: (p) => `应用到 ${p}？`,
+    updated: (p) => `已更新 ${p}`,
+    commitHint: "提交并推送。新配置会在下一次向任意开放 PR 推送时生效。",
+  },
+
+  doctor: {
+    title: "OrcaCode Review —— 体检",
+    repo: (name) => `  仓库 ${name}`,
+    repoUnknown: "（未知）",
+    workflowExists: (p) => `${p} 存在`,
+    workflowMissing: (p) => `缺少 ${p}`,
+    workflowMissingFix: "运行：npx orcacode-review init",
+    onBase: (b) => `已在 origin/${b} 上`,
+    notOnBase: (b) => `还没进 origin/${b}`,
+    notOnBaseFix: "pull_request_target 从「目标分支」读取 workflow。合并进去之后才会有运行记录。",
+    noGh: "GitHub CLI 不可用或未登录 —— 跳过密钥、运行记录和门禁检查。",
+    noGhHint: "  从 https://cli.github.com 安装并运行 `gh auth login` 可获得完整报告。",
+    secretSet: (s) => `仓库密钥 ${s} 已配置`,
+    secretMissing: (s) => `找不到仓库密钥 ${s}`,
+    secretMissingFix: (s, url) => `运行：gh secret set ${s}   （密钥来自 ${url}）`,
+    runsUnreadable: "无法读取运行记录（这个 workflow 可能从没跑过）。",
+    noRuns: "这个 workflow 没有任何运行记录",
+    noRunsFix:
+      "常见原因：控制台里应用没开、auto_review 关着、trigger=ready_for_review 时 PR\n" +
+      "  还是草稿，或者作者不在 auto-review-authors 白名单里。",
+    recentRuns: (n) => `最近 ${n} 次运行：`,
+    inspectFailure: "查看失败详情：gh run view <run-id> --log-failed",
+    gateRequired: (b) => `${b} 上「review」检查已设为必需`,
+    gateMissing: (b) => `${b} 上「review」检查「不是」必需的`,
+    gateMissingFix: "问题照样会评论出来，但拦不住合并。Settings → Branches / Rulesets → Require status checks。",
+    noProtection: (b) => `读不到 ${b} 的分支保护 —— 合并没有门禁。`,
+    clean: "没有发现问题。",
+    problems: (n) => `发现 ${n} 个问题 —— 修复方式见上。`,
+    problemsHint: "  完整的「现象 → 原因 → 修复」表：skills/setup-orca-code-review/references/troubleshooting.md",
+  },
+
+  uninstall: {
+    title: "OrcaCode Review —— 卸载",
+    nothing: (p) => `没什么可删的 —— 不存在 ${p}。`,
+    gateFirst:
+      "请「先」取消必需的「review」检查。\n" +
+      "  workflow 都删了，必需检查就永远不会上报，所有 PR 会被永久卡住，没有任何\n" +
+      "  办法解开。",
+    gateWhere: (repo, branch) => `  ${repo} 的 Settings → Branches / Rulesets（${branch}）`,
+    deleteConfirm: (p) => `现在删除 ${p}？`,
+    removed: (p) => `已删除 ${p}`,
+    keepSecret: (s) => `  • ${s} 密钥留着没有坏处，以后想重装还用得上。`,
+    disableApp: (url) => `  • 去 ${url} → Apps → OrcaCode Review 关掉应用，停止计费。`,
+    keepComments: "  • 已有的评审评论会保留 —— 它们是 PR 历史的一部分。",
+  },
+
+  skill: {
+    missingBundle: "这个包里缺少内置的 skill。",
+    missingBundleHint: "重新安装：npx orcacode-review@latest skill",
+    scopeQ: "skill 装到哪里？",
+    scopeProject: "当前项目",
+    scopeProjectDetail: "随仓库提交 —— 每个 clone 的人都能用。",
+    scopeGlobal: "当前用户",
+    scopeGlobalDetail: "本机所有项目都能用。",
+    unknownScope: (s) => `未知的安装范围「${s}」。`,
+    unknownScopeHint: "用 --scope project 或 --scope global。",
+    unknownPlatform: (id) => `未知平台「${id}」。`,
+    unknownPlatformHint: "用 orcacode-review skill list 查看全部。",
+    noneDetected: "这里没检测到任何 Agent 平台，也没有指定平台。",
+    noneDetectedHint: "请显式指定，例如 --platform claude --platform codex（`skill list` 列出全部 36 个）。",
+    platformQ: "要把 skill 装到哪些 Agent？",
+    platformCount: (n) => `（检测到 ${n} 个）`,
+    statusUpdated: "（已更新）",
+    statusUnchanged: "（已是最新）",
+    statusConflict: "（已跳过 —— 那里存在一份内容不同的副本）",
+    forceHint: "加 --force 重新运行可覆盖内容不同的副本。",
+    askAgent: "对你的 Agent 说：「帮我在这个仓库配置 OrcaCode Review」。",
+    pluginHint: "  Claude Code 建议改用插件，它会自动保持更新：",
+    listTitle: (n) => `支持 ${n} 个平台`,
+    listColumns: "  （项目路径 / 全局路径）",
+    listLegend: "  ● = 本机已检测到。安装：orcacode-review skill install --platform <id>",
+  },
+
+  secret: {
+    title: (s) => `仓库密钥：${s}`,
+    createHint: (url) => `  在 ${url} 创建或复制一个 key`,
+    alreadySet: (s) => `${s} 已经配置好了。`,
+    setNow: "现在用 GitHub CLI 配置它？",
+    wasSet: (s) => `${s} 已配置。`,
+    ghFailed: "gh 没能设置密钥。改在浏览器里加：",
+    addManually: (s) => `  添加一个名为 ${s} 的密钥：`,
+    manualPath: "你的仓库 → Settings → Secrets and variables → Actions → New repository secret",
+  },
+
+  usage: {
+    tagline: "OrcaCode Review 安装器（由 OrcaRouter 驱动的 AI PR 评审）",
+    usage: "用法",
+    commands: "命令",
+    options: "参数",
+    examples: "示例",
+    docs: "文档",
+    cmdInit: "写入 .github/workflows/orca-code-review.yml（默认命令）",
+    cmdReconfigure: "修改已有 workflow 的参数",
+    cmdDoctor: "排查装好但不工作的问题",
+    cmdUninstall: "移除 workflow",
+    cmdSkillInstall: (n) => `安装 Agent Skill（${n} 个平台）`,
+    cmdSkillList: "列出支持的平台，并标出本机检测到的",
+    optYes: "使用推荐默认值，不再询问",
+    optForce: "直接覆盖，不询问",
+    optJson: "机器可读输出（skill install / skill list）",
+    optLang: "界面语言：zh | en（默认跟随系统 locale）",
+    optNoBanner: "不显示字符画标题",
+    optScope: "用于 `skill`：project | global",
+    optPlatform: "用于 `skill`：可重复；不指定则交互选择",
+    optHelp: "显示本帮助",
+    optVersion: "显示版本号",
+  },
+};
+
+const STRINGS = { en: EN, zh: ZH };
+
+const lookup = (table, key) => key.split(".").reduce((node, part) => node?.[part], table);
+
+/** Returns a `t(key, ...args)` bound to one language, falling back to English. */
+export function makeT(language) {
+  const primary = STRINGS[language] ?? STRINGS.en;
+  return (key, ...args) => {
+    const value = lookup(primary, key) ?? lookup(STRINGS.en, key);
+    if (value === undefined) return key; // visible in output, never a crash
+    return typeof value === "function" ? value(...args) : value;
+  };
+}
+
+export const TABLES = STRINGS;

--- a/bin/orcacode-review.mjs
+++ b/bin/orcacode-review.mjs
@@ -1,0 +1,914 @@
+#!/usr/bin/env node
+// OrcaCode Review installer — `npx orcacode-review`.
+//
+//   npx orcacode-review                interactive menu
+//   npx orcacode-review init           write .github/workflows/orca-code-review.yml
+//   npx orcacode-review reconfigure    change the inputs in an existing workflow
+//   npx orcacode-review doctor         diagnose an install that is not working
+//   npx orcacode-review uninstall      remove the workflow (gate first, file second)
+//   npx orcacode-review skill install  install the agent skill (36 platforms)
+//   npx orcacode-review skill list     list the platforms and what is detected here
+//
+// Zero dependencies on purpose: `npx` downloads the whole tree before it runs
+// anything, so every dependency is latency the user pays at install time and a
+// supply-chain edge on a tool whose whole job is touching CI config.
+//
+// The API key is never read, echoed, or passed as an argv value — argv is
+// visible in `ps`. `gh secret set` is spawned with inherited stdio so the user
+// types it into gh, not into this process.
+//
+// All prose comes from i18n.mjs (zh/en). Flag names, platform IDs, workflow
+// inputs, and shell commands are never translated — the reader still has to
+// type them.
+
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import { SKILL_PLATFORMS, POPULAR_PLATFORM_IDS, findPlatform, detectPlatforms, resolveTargets } from "./platforms.mjs";
+import { installTree, STATUS } from "./skill-tree.mjs";
+import { makeT, detectLanguage, parseLanguage } from "./i18n.mjs";
+import { renderBanner } from "./banner.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = path.resolve(HERE, "..");
+const WORKFLOW_REL = ".github/workflows/orca-code-review.yml";
+const SECRET = "ORCAROUTER_API_KEY";
+const ACTION_REF = "Continuum-AI-Corp/orca-code-review@v1";
+const CONSOLE_TOKENS = "https://www.orcarouter.ai/console/token";
+const CONSOLE_APPS = "https://www.orcarouter.ai/";
+const SKILL_NAME = "setup-orca-code-review";
+
+// Resolved from the locale up front so every path — including an early `die()`
+// during argument parsing — has a working translator.
+let LANG = detectLanguage();
+let t = makeT(LANG);
+
+const setLanguage = (lang) => { LANG = lang; t = makeT(lang); };
+
+// ---------------------------------------------------------------- output ---
+
+const tty = process.stdout.isTTY && !process.env.NO_COLOR;
+const c = (code) => (s) => (tty ? `\x1b[${code}m${s}\x1b[0m` : String(s));
+const bold = c(1);
+const dim = c(2);
+const red = c(31);
+const green = c(32);
+const yellow = c(33);
+const cyan = c(36);
+
+const say = (s = "") => console.log(s);
+const ok = (s) => say(`${green("✔")} ${s}`);
+const warn = (s) => say(`${yellow("!")} ${s}`);
+const info = (s) => say(`${cyan("›")} ${s}`);
+const fail = (s) => {
+  console.error(`${red("✖")} ${s}`);
+  process.exitCode = 1;
+};
+
+function die(msg, hint) {
+  console.error(`${red("✖")} ${msg}`);
+  if (hint) console.error(`  ${dim(hint)}`);
+  process.exit(1);
+}
+
+function showBanner(argv) {
+  if (argv?.noBanner || argv?.json || !process.stdout.isTTY) return;
+  say();
+  renderBanner((s) => process.stdout.write(s), { color: tty });
+}
+
+// ------------------------------------------------------------------ shell ---
+
+// Never throws: a missing binary and a nonzero exit are both just "not ok", and
+// every caller here treats them the same way.
+function sh(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { encoding: "utf8", ...opts });
+  return {
+    ok: r.status === 0,
+    out: (r.stdout || "").trim(),
+    err: (r.error?.message || r.stderr || "").trim(),
+  };
+}
+
+const hasGh = () => sh("gh", ["--version"]).ok;
+const ghAuthed = () => sh("gh", ["auth", "status"]).ok;
+
+// ----------------------------------------------------------------- prompts ---
+
+let rl = null;
+const ui = () => (rl ??= readline.createInterface({ input: process.stdin, output: process.stdout }));
+const closeUi = () => { rl?.close(); rl = null; };
+
+let ASSUME_YES = false;
+
+function requireInteractive(what) {
+  if (ASSUME_YES) return false;
+  if (process.stdin.isTTY) return true;
+  die(t("common.nonTTY", what), t("common.nonTTYHint"));
+}
+
+// A numbered single-choice prompt. `options` is [{label, value, detail, recommended}].
+async function select(question, options, { defaultIndex = 0 } = {}) {
+  if (!requireInteractive(question)) return options[defaultIndex].value;
+
+  say();
+  say(bold(question));
+  options.forEach((o, i) => {
+    const tag = o.recommended ? dim(` ${t("common.recommended")}`) : "";
+    say(`  ${cyan(String(i + 1))}. ${o.label}${tag}`);
+    if (o.detail) say(`     ${dim(o.detail)}`);
+  });
+
+  for (;;) {
+    const raw = (await ui().question(dim(t("common.chooseRange", options.length, defaultIndex + 1)))).trim();
+    if (raw === "") return options[defaultIndex].value;
+    const n = Number(raw);
+    if (Number.isInteger(n) && n >= 1 && n <= options.length) return options[n - 1].value;
+    warn(t("common.enterNumber", options.length));
+  }
+}
+
+// A numbered checkbox list. Accepts "1,3,5", ranges ("1-4"), "a" for all, and
+// bare Enter for the preselected set.
+async function multiSelect(question, options, { preselected = [] } = {}) {
+  const chosen = new Set(preselected);
+  if (!requireInteractive(question)) return options.filter((o) => chosen.has(o.value)).map((o) => o.value);
+
+  say();
+  say(bold(question));
+  options.forEach((o, i) => {
+    const mark = chosen.has(o.value) ? green("[x]") : dim("[ ]");
+    const tag = o.detected ? green(`  ← ${t("common.detected")}`) : "";
+    say(`  ${mark} ${cyan(String(i + 1).padStart(2))}. ${o.label}${tag}`);
+  });
+  say(dim(`     ${t("common.multiHint")}`));
+
+  for (;;) {
+    const raw = (await ui().question(dim(t("common.selectPrompt")))).trim().toLowerCase();
+    if (raw === "") {
+      if (chosen.size > 0) break;
+      warn(t("common.nothingSelected"));
+      continue;
+    }
+    if (raw === "a" || raw === "all") return options.map((o) => o.value);
+
+    const picked = new Set();
+    let bad = false;
+    for (const part of raw.split(",").map((s) => s.trim()).filter(Boolean)) {
+      const range = part.match(/^(\d+)-(\d+)$/);
+      const nums = range
+        ? Array.from({ length: Number(range[2]) - Number(range[1]) + 1 }, (_, k) => Number(range[1]) + k)
+        : [Number(part)];
+      for (const n of nums) {
+        if (!Number.isInteger(n) || n < 1 || n > options.length) { bad = true; break; }
+        picked.add(options[n - 1].value);
+      }
+      if (bad) break;
+    }
+    if (bad || picked.size === 0) { warn(t("common.enterNumber", options.length)); continue; }
+    return [...picked];
+  }
+  return [...chosen];
+}
+
+async function confirm(question, defaultYes = true) {
+  if (!requireInteractive(question)) return defaultYes;
+  const suffix = defaultYes ? "[Y/n]" : "[y/N]";
+  const raw = (await ui().question(`${bold(question)} ${dim(suffix)} `)).trim().toLowerCase();
+  if (raw === "") return defaultYes;
+  return raw === "y" || raw === "yes";
+}
+
+// The language screen, shown once at the top of a guided flow when --lang was
+// not given. Its own label is bilingual, so it reads correctly before a
+// language has been chosen.
+async function askLanguage(argv) {
+  if (argv.lang || ASSUME_YES || !process.stdin.isTTY) return;
+  const picked = await select(
+    t("lang.question"),
+    [
+      { label: t("lang.en"), value: "en" },
+      { label: t("lang.zh"), value: "zh" },
+    ],
+    { defaultIndex: LANG === "zh" ? 1 : 0 },
+  );
+  setLanguage(picked);
+}
+
+// -------------------------------------------------------------- repo state ---
+
+function repoState() {
+  const top = sh("git", ["rev-parse", "--show-toplevel"]);
+  if (!top.ok) die(t("common.notGitRepo"), t("common.notGitRepoHint"));
+  const root = top.out;
+
+  const state = {
+    root,
+    workflowPath: path.join(root, WORKFLOW_REL),
+    installed: fs.existsSync(path.join(root, WORKFLOW_REL)),
+    nameWithOwner: null,
+    visibility: null,
+    defaultBranch: null,
+    gh: hasGh() && ghAuthed(),
+  };
+
+  if (state.gh) {
+    const v = sh("gh", ["repo", "view", "--json", "nameWithOwner,visibility,defaultBranchRef"], { cwd: root });
+    if (v.ok) {
+      try {
+        const j = JSON.parse(v.out);
+        state.nameWithOwner = j.nameWithOwner ?? null;
+        state.visibility = j.visibility ?? null;
+        state.defaultBranch = j.defaultBranchRef?.name ?? null;
+      } catch {
+        /* leave the fields null — everything downstream degrades to URLs */
+      }
+    }
+  }
+
+  // Fall back to the remote URL so we can still print correct links without gh.
+  if (!state.nameWithOwner) {
+    const u = sh("git", ["remote", "get-url", "origin"], { cwd: root });
+    const m = u.ok && u.out.match(/github\.com[:/]+([^/]+\/[^/]+?)(?:\.git)?$/);
+    if (m) state.nameWithOwner = m[1];
+  }
+
+  return state;
+}
+
+// ---------------------------------------------------------------- template ---
+
+// Only inputs that differ from their documented default are written. A workflow
+// that lists what it overrides and nothing else stays readable, and — with
+// `settings: "true"` — an input equal to its default would not change behavior
+// anyway, so writing it would only imply a control the file does not have.
+export const DEFAULTS = Object.freeze({
+  settings: "true",
+  "block-on": "P0,P1",
+  "on-oversized-diff": "fail",
+  "auto-review-authors": "",
+});
+
+// Generated workflow comments stay English: the file is committed and read by
+// everyone on the repo, and CI config in a language half the team cannot read
+// is worse than none.
+const INPUT_NOTES = {
+  settings: '"false" makes this file authoritative — no dashboard override',
+  "block-on": "severities that fail the check (block the merge)",
+  "on-oversized-diff": '"pass" makes an oversized-diff skip advisory',
+  "auto-review-authors": "author allowlist for AUTOMATIC reviews",
+};
+
+export function renderWorkflow(overrides) {
+  const lines = Object.entries(overrides)
+    .filter(([k, v]) => v !== undefined && v !== DEFAULTS[k])
+    .map(([k, v]) => `          ${k}: ${JSON.stringify(v)}${INPUT_NOTES[k] ? `  # ${INPUT_NOTES[k]}` : ""}`);
+
+  const withBlock = [
+    `          orcarouter-api-key: \${{ secrets.${SECRET} }}`,
+    ...lines,
+  ].join("\n");
+
+  return `# OrcaCode Review — https://github.com/Continuum-AI-Corp/orca-code-review
+#
+# Generated by \`npx orcacode-review\`. The review logic lives in the published
+# action, so this file never copies scripts or config — bump the version tag to
+# update. Add one repository secret, ${SECRET}, and enable the app at
+# OrcaRouter -> Apps -> OrcaCode Review.
+
+name: OrcaCode Review
+
+concurrency:
+  group: \${{ github.workflow }}-\${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  # \`synchronize\` re-reviews on every new push. \`ready_for_review\` makes the
+  # dashboard's trigger=ready_for_review mode fire when a draft becomes ready.
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write # tier state label + clean/fallback PR comments
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    # Run on PR events, or when a trusted user comments the review command on a
+    # PR. All four spellings are accepted — either prefix (\`/\` or \`@\`) with
+    # either separator (hyphen or space). The command runs this privileged
+    # \`pull_request_target\` workflow with the OrcaRouter secret, so only
+    # maintainers may trigger it — otherwise any participant could burn paid
+    # quota and spam reviews without pushing new commits.
+    if: |
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        (startsWith(github.event.comment.body, '/orcacode-review') ||
+          startsWith(github.event.comment.body, '/orcacode review') ||
+          startsWith(github.event.comment.body, '@orcacode-review') ||
+          startsWith(github.event.comment.body, '@orcacode review')) &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    steps:
+      - uses: ${ACTION_REF}
+        with:
+${withBlock}
+`;
+}
+
+// Best-effort read-back of what the current file overrides, so `reconfigure`
+// can show real before-values instead of pretending everything is default.
+export function readOverrides(file) {
+  return parseOverrides(fs.readFileSync(file, "utf8"));
+}
+
+export function parseOverrides(text) {
+  const found = { ...DEFAULTS };
+  for (const key of Object.keys(DEFAULTS)) {
+    const m = text.match(new RegExp(`^\\s*${key}:\\s*["']?([^"'#\\n]*)["']?`, "m"));
+    if (m) found[key] = m[1].trim();
+  }
+  return found;
+}
+
+// ------------------------------------------------------------------ config ---
+
+async function askConfig(state, current = DEFAULTS) {
+  const out = {};
+
+  out.settings = await select(
+    t("config.settingsQ"),
+    [
+      { label: t("config.settingsDashboard"), value: "true", recommended: true, detail: t("config.settingsDashboardDetail") },
+      { label: t("config.settingsFile"), value: "false", detail: t("config.settingsFileDetail") },
+    ],
+    { defaultIndex: current.settings === "false" ? 1 : 0 },
+  );
+
+  const blockOptions = ["P0,P1", "P0", ""];
+  out["block-on"] = await select(
+    t("config.blockQ"),
+    [
+      { label: t("config.blockBoth"), value: "P0,P1", recommended: true, detail: t("config.blockBothDetail") },
+      { label: t("config.blockP0"), value: "P0", detail: t("config.blockP0Detail") },
+      { label: t("config.blockNone"), value: "", detail: t("config.blockNoneDetail") },
+    ],
+    { defaultIndex: Math.max(0, blockOptions.indexOf(current["block-on"])) },
+  );
+
+  out["on-oversized-diff"] = await select(
+    t("config.oversizedQ"),
+    [
+      { label: t("config.oversizedFail"), value: "fail", recommended: true, detail: t("config.oversizedFailDetail") },
+      { label: t("config.oversizedPass"), value: "pass", detail: t("config.oversizedPassDetail") },
+    ],
+    { defaultIndex: current["on-oversized-diff"] === "pass" ? 1 : 0 },
+  );
+
+  // Only a public repo has this problem, and only a public repo should be asked.
+  if (state.visibility === "PUBLIC") {
+    say();
+    warn(t("config.publicWarning", CONSOLE_TOKENS));
+    out["auto-review-authors"] = await select(
+      t("config.authorsQ"),
+      [
+        {
+          label: t("config.authorsKnown"),
+          value: "OWNER,MEMBER,COLLABORATOR,CONTRIBUTOR",
+          recommended: true,
+          detail: t("config.authorsKnownDetail"),
+        },
+        { label: t("config.authorsAll"), value: "", detail: t("config.authorsAllDetail") },
+      ],
+    );
+  } else if (current["auto-review-authors"]) {
+    out["auto-review-authors"] = current["auto-review-authors"];
+  }
+
+  return out;
+}
+
+// -------------------------------------------------------------- subcommands ---
+
+async function cmdInit(argv) {
+  const state = repoState();
+
+  say();
+  say(bold(t("init.title")));
+  say(dim(t("init.repo", state.nameWithOwner ?? t("init.repoUnknown"))));
+  say(dim(t("init.workflow", WORKFLOW_REL)));
+
+  if (state.installed && !argv.force) {
+    warn(t("init.exists"));
+    const go = await confirm(t("init.reconfigureInstead"), true);
+    closeUi();
+    if (go) return cmdReconfigure(argv);
+    info(t("init.unchangedHint"));
+    return;
+  }
+
+  const cfg = await askConfig(state);
+  const yaml = renderWorkflow(cfg);
+
+  say();
+  say(bold(t("init.preview")));
+  say(dim(yaml.split("\n").map((l) => `  ${l}`).join("\n")));
+
+  if (!(await confirm(t("init.writeConfirm", WORKFLOW_REL), true))) {
+    closeUi();
+    info(t("common.aborted"));
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(state.workflowPath), { recursive: true });
+  fs.writeFileSync(state.workflowPath, yaml);
+  ok(t("init.wrote", WORKFLOW_REL));
+
+  await setupSecret(state);
+  closeUi();
+
+  say();
+  say(bold(t("init.remaining")));
+  say(t("init.step1", cyan(CONSOLE_APPS)));
+  say(dim(t("init.step1Note")));
+  say(t("init.step2"));
+  say(dim(t("init.step2Note")));
+  say(t("init.step3"));
+  say(dim(t("init.step3Note", "review")));
+  say();
+  say(dim(t("init.diagnoseHint")));
+}
+
+async function cmdReconfigure(argv) {
+  const state = repoState();
+  if (!state.installed) die(t("reconfigure.missing", WORKFLOW_REL), t("reconfigure.missingHint"));
+
+  const current = readOverrides(state.workflowPath);
+
+  say();
+  say(bold(t("reconfigure.title")));
+  if (current.settings !== "false") {
+    say();
+    info(t("reconfigure.dashboardOwns"));
+    say(dim(t("reconfigure.dashboardOwnsDetail", CONSOLE_APPS)));
+  }
+
+  const cfg = await askConfig(state, current);
+
+  const changed = Object.entries(cfg).filter(([k, v]) => v !== current[k]);
+  if (changed.length === 0) {
+    closeUi();
+    ok(t("reconfigure.noChanges"));
+    return;
+  }
+
+  say();
+  say(bold(t("reconfigure.changes")));
+  for (const [k, v] of changed) {
+    say(`  ${k}: ${dim(JSON.stringify(current[k]))} → ${bold(JSON.stringify(v))}`);
+  }
+
+  if (!(await confirm(t("reconfigure.applyConfirm", WORKFLOW_REL), true))) {
+    closeUi();
+    info(t("common.aborted"));
+    return;
+  }
+
+  fs.writeFileSync(state.workflowPath, renderWorkflow(cfg));
+  closeUi();
+  ok(t("reconfigure.updated", WORKFLOW_REL));
+  info(t("reconfigure.commitHint"));
+}
+
+async function cmdDoctor() {
+  const state = repoState();
+
+  say();
+  say(bold(t("doctor.title")));
+  say(dim(t("doctor.repo", state.nameWithOwner ?? t("doctor.repoUnknown"))));
+  say();
+
+  let problems = 0;
+  const bad = (s, fix) => { problems++; fail(s); if (fix) say(`  ${dim(fix)}`); };
+
+  // 1. Workflow present locally.
+  if (state.installed) ok(t("doctor.workflowExists", WORKFLOW_REL));
+  else bad(t("doctor.workflowMissing", WORKFLOW_REL), t("doctor.workflowMissingFix"));
+
+  // 2. Workflow present on the base branch — the one that actually matters.
+  //    pull_request_target reads the workflow from the base branch, so a file
+  //    that exists only on a feature branch produces no runs and no error.
+  if (state.installed && state.defaultBranch) {
+    const onBase = sh("git", ["cat-file", "-e", `origin/${state.defaultBranch}:${WORKFLOW_REL}`], { cwd: state.root });
+    if (onBase.ok) ok(t("doctor.onBase", state.defaultBranch));
+    else bad(t("doctor.notOnBase", state.defaultBranch), t("doctor.notOnBaseFix"));
+  }
+
+  if (!state.gh) {
+    say();
+    warn(t("doctor.noGh"));
+    say(dim(t("doctor.noGhHint")));
+    return summarize(problems);
+  }
+
+  // 3. The secret. Existence only — the value is never fetched or printed.
+  const secrets = sh("gh", ["secret", "list", "--json", "name"], { cwd: state.root });
+  if (secrets.ok && /"name"\s*:\s*"ORCAROUTER_API_KEY"/.test(secrets.out)) {
+    ok(t("doctor.secretSet", SECRET));
+  } else {
+    bad(t("doctor.secretMissing", SECRET), t("doctor.secretMissingFix", SECRET, CONSOLE_TOKENS));
+  }
+
+  // 4. Recent runs.
+  const runs = sh(
+    "gh",
+    ["run", "list", "--workflow", "orca-code-review.yml", "--limit", "5", "--json", "conclusion,status,headBranch,createdAt"],
+    { cwd: state.root },
+  );
+  if (!runs.ok) {
+    warn(t("doctor.runsUnreadable"));
+  } else {
+    let list = [];
+    try { list = JSON.parse(runs.out); } catch { /* fall through to the empty case */ }
+    if (list.length === 0) {
+      bad(t("doctor.noRuns"), t("doctor.noRunsFix"));
+    } else {
+      ok(t("doctor.recentRuns", list.length));
+      for (const r of list) {
+        const mark = r.conclusion === "success" ? green("pass") : r.conclusion ? red(r.conclusion) : yellow(r.status);
+        say(`    ${mark}  ${r.headBranch}  ${dim(r.createdAt)}`);
+      }
+      if (list.some((r) => r.conclusion === "failure")) info(t("doctor.inspectFailure"));
+    }
+  }
+
+  // 5. The gate. A red check blocks nothing until it is required.
+  if (state.defaultBranch && state.nameWithOwner) {
+    const prot = sh(
+      "gh",
+      ["api", `repos/${state.nameWithOwner}/branches/${state.defaultBranch}/protection/required_status_checks`],
+      { cwd: state.root },
+    );
+    if (prot.ok && /"review"/.test(prot.out)) ok(t("doctor.gateRequired", state.defaultBranch));
+    else if (prot.ok) bad(t("doctor.gateMissing", state.defaultBranch), t("doctor.gateMissingFix"));
+    else warn(t("doctor.noProtection", state.defaultBranch));
+  }
+
+  return summarize(problems);
+}
+
+function summarize(problems) {
+  say();
+  if (problems === 0) ok(bold(t("doctor.clean")));
+  else {
+    fail(t("doctor.problems", problems));
+    say(dim(t("doctor.problemsHint")));
+  }
+}
+
+async function cmdUninstall() {
+  const state = repoState();
+  if (!state.installed) {
+    info(t("uninstall.nothing", WORKFLOW_REL));
+    return;
+  }
+
+  say();
+  say(bold(t("uninstall.title")));
+  say();
+  warn(t("uninstall.gateFirst"));
+  if (state.nameWithOwner && state.defaultBranch) {
+    say(dim(t("uninstall.gateWhere", state.nameWithOwner, state.defaultBranch)));
+  }
+
+  if (!(await confirm(t("uninstall.deleteConfirm", WORKFLOW_REL), false))) {
+    closeUi();
+    info(t("common.abortedRemoval"));
+    return;
+  }
+
+  fs.rmSync(state.workflowPath);
+  closeUi();
+  ok(t("uninstall.removed", WORKFLOW_REL));
+  say();
+  say(t("uninstall.keepSecret", SECRET));
+  say(t("uninstall.disableApp", cyan(CONSOLE_APPS)));
+  say(t("uninstall.keepComments"));
+}
+
+// ------------------------------------------------------------------- skill ---
+
+const homeDir = () => process.env.HOME || process.env.USERPROFILE || "";
+const lookPath = (exe) => sh(process.platform === "win32" ? "where" : "which", [exe]).ok;
+
+async function cmdSkill(argv) {
+  const source = path.join(PKG_ROOT, "skills", SKILL_NAME);
+  if (!fs.existsSync(source)) die(t("skill.missingBundle"), t("skill.missingBundleHint"));
+
+  const home = homeDir();
+  // Detection always looks at the working directory, even for a global install:
+  // "which agents does this person use" is answered by the project they are
+  // standing in, not by where the files will land.
+  const cwd = process.cwd();
+  const detected = detectPlatforms(cwd, home, lookPath);
+
+  const scope = argv.scope ?? (await select(
+    t("skill.scopeQ"),
+    [
+      { label: t("skill.scopeProject"), value: "project", recommended: true, detail: t("skill.scopeProjectDetail") },
+      { label: t("skill.scopeGlobal"), value: "global", detail: t("skill.scopeGlobalDetail") },
+    ],
+  ));
+  if (scope !== "project" && scope !== "global") {
+    die(t("skill.unknownScope", scope), t("skill.unknownScopeHint"));
+  }
+
+  let platformIds = argv.platforms ?? [];
+  for (const id of platformIds) {
+    if (!findPlatform(id)) die(t("skill.unknownPlatform", id), t("skill.unknownPlatformHint"));
+  }
+
+  if (platformIds.length === 0) {
+    if (ASSUME_YES || !process.stdin.isTTY) {
+      // Unattended: install to what is actually here. Falling back to "all 36"
+      // would scatter directories across a machine nobody asked us to touch.
+      platformIds = detected;
+      if (platformIds.length === 0) die(t("skill.noneDetected"), t("skill.noneDetectedHint"));
+    } else {
+      // Detected first, then the popular names, then the long tail — so the
+      // list opens on something recognizable instead of 36 rows of alphabet soup.
+      const rank = (p) => (detected.includes(p.id) ? 0 : POPULAR_PLATFORM_IDS.includes(p.id) ? 1 : 2);
+      const options = [...SKILL_PLATFORMS]
+        .map((p, i) => ({ p, i }))
+        .sort((a, b) => rank(a.p) - rank(b.p) || a.i - b.i)
+        .map(({ p }) => ({ label: p.name, value: p.id, detected: detected.includes(p.id) }));
+
+      platformIds = await multiSelect(
+        `${t("skill.platformQ")}${detected.length ? dim(t("skill.platformCount", detected.length)) : ""}`,
+        options,
+        { preselected: detected },
+      );
+    }
+  }
+
+  // Prefer the git root so a `skill install` from a subdirectory lands beside
+  // the repo's other agent config, but do not require a repo — plenty of people
+  // keep a scratch directory with an AGENTS setup and no git.
+  const gitRoot = sh("git", ["rev-parse", "--show-toplevel"], { cwd });
+  const projectDir = scope === "project" && gitRoot.ok ? gitRoot.out : cwd;
+  const targets = resolveTargets({ platformIds, scope, projectDir, homeDir: home, skillName: SKILL_NAME });
+
+  const results = targets.map((target) => {
+    try {
+      return { ...target, status: installTree(source, target.path, { force: argv.force }) };
+    } catch (e) {
+      return { ...target, status: STATUS.error, error: e.message };
+    }
+  });
+
+  closeUi();
+
+  if (argv.json) {
+    say(JSON.stringify({ scope, source, results }, null, 2));
+    if (results.some((r) => r.status === STATUS.error)) process.exitCode = 1;
+    return;
+  }
+
+  say();
+  for (const r of results) {
+    const names = r.platformNames.join(", ");
+    const where = dim(path.relative(scope === "project" ? projectDir : home, r.path) || r.path);
+    switch (r.status) {
+      case STATUS.installed: ok(`${names}  ${where}`); break;
+      case STATUS.updated: ok(`${names}  ${where} ${dim(t("skill.statusUpdated"))}`); break;
+      case STATUS.unchanged: say(`${dim("·")} ${names}  ${where} ${dim(t("skill.statusUnchanged"))}`); break;
+      case STATUS.conflict: warn(`${names}  ${where} ${dim(t("skill.statusConflict"))}`); break;
+      default: fail(`${names}  ${where} — ${r.error}`);
+    }
+  }
+
+  if (results.some((r) => r.status === STATUS.conflict)) {
+    say();
+    info(t("skill.forceHint"));
+  }
+  if (results.some((r) => r.status === STATUS.error)) process.exitCode = 1;
+
+  const installed = results.filter((r) => r.status === STATUS.installed || r.status === STATUS.updated);
+  if (installed.length > 0) {
+    say();
+    info(t("skill.askAgent"));
+    if (installed.some((r) => r.platformIds.includes("claude"))) {
+      say(dim(t("skill.pluginHint")));
+      say(dim("    /plugin marketplace add Continuum-AI-Corp/orca-code-review"));
+      say(dim("    /plugin install orca-code-review"));
+    }
+  }
+}
+
+function cmdListPlatforms(argv) {
+  const detected = detectPlatforms(process.cwd(), homeDir(), lookPath);
+  if (argv.json) {
+    return say(JSON.stringify(
+      SKILL_PLATFORMS.map((p) => ({ ...p, detected: detected.includes(p.id) })),
+      null,
+      2,
+    ));
+  }
+  say();
+  say(bold(t("skill.listTitle", SKILL_PLATFORMS.length)) + dim(t("skill.listColumns")));
+  for (const p of SKILL_PLATFORMS) {
+    const mark = detected.includes(p.id) ? green("●") : dim("○");
+    say(`  ${mark} ${p.id.padEnd(16)} ${p.name.padEnd(22)} ${dim(`${p.projectRoot}/skills/  ~/${p.globalRoot}/skills/`)}`);
+  }
+  say();
+  say(dim(t("skill.listLegend")));
+}
+
+// ------------------------------------------------------------------ secret ---
+
+async function setupSecret(state) {
+  say();
+  say(bold(t("secret.title", SECRET)));
+  say(dim(t("secret.createHint", CONSOLE_TOKENS)));
+
+  if (state.gh) {
+    const list = sh("gh", ["secret", "list", "--json", "name"], { cwd: state.root });
+    if (list.ok && /"name"\s*:\s*"ORCAROUTER_API_KEY"/.test(list.out)) {
+      ok(t("secret.alreadySet", SECRET));
+      return;
+    }
+    // `gh secret set` prompts for the value, so it needs a real terminal. Under
+    // --yes or a piped stdin there is nobody to type the key — offering it would
+    // just hand the user a confusing gh error instead of the manual URL.
+    const canPrompt = process.stdin.isTTY && !ASSUME_YES;
+    if (canPrompt && (await confirm(t("secret.setNow"), true))) {
+      // Inherited stdio: gh prompts for the value directly. It never passes
+      // through this process, so it cannot land in argv, a log, or scrollback.
+      const r = spawnSync("gh", ["secret", "set", SECRET], { cwd: state.root, stdio: "inherit" });
+      if (r.status === 0) { ok(t("secret.wasSet", SECRET)); return; }
+      warn(t("secret.ghFailed"));
+    }
+  }
+
+  const url = state.nameWithOwner
+    ? `https://github.com/${state.nameWithOwner}/settings/secrets/actions/new`
+    : t("secret.manualPath");
+  say(t("secret.addManually", bold(SECRET)));
+  say(`  ${cyan(url)}`);
+}
+
+// -------------------------------------------------------------------- main ---
+
+function usage() {
+  const n = SKILL_PLATFORMS.length;
+  say(`${bold("orcacode-review")} — ${t("usage.tagline")}
+
+${bold(t("usage.usage"))}
+  npx orcacode-review [command] [options]
+
+${bold(t("usage.commands"))}
+  init             ${t("usage.cmdInit")}
+  reconfigure      ${t("usage.cmdReconfigure")}
+  doctor           ${t("usage.cmdDoctor")}
+  uninstall        ${t("usage.cmdUninstall")}
+  skill install    ${t("usage.cmdSkillInstall", n)}
+  skill list       ${t("usage.cmdSkillList")}
+
+${bold(t("usage.options"))}
+  --yes, -y        ${t("usage.optYes")}
+  --force          ${t("usage.optForce")}
+  --json           ${t("usage.optJson")}
+  --lang <zh|en>   ${t("usage.optLang")}
+  --no-banner      ${t("usage.optNoBanner")}
+  --scope <s>      ${t("usage.optScope")}
+  --platform <id>  ${t("usage.optPlatform")}
+  --help, -h       ${t("usage.optHelp")}
+  --version, -v    ${t("usage.optVersion")}
+
+${bold(t("usage.examples"))}
+  npx orcacode-review skill install --platform claude --platform codex --yes
+  npx orcacode-review skill install --scope global --platform cursor --lang zh
+
+${bold(t("usage.docs"))}  https://github.com/Continuum-AI-Corp/orca-code-review`);
+}
+
+function parse(args) {
+  const out = { _: [] };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--yes" || a === "-y") out.yes = true;
+    else if (a === "--force") out.force = true;
+    else if (a === "--help" || a === "-h") out.help = true;
+    else if (a === "--version" || a === "-v") out.version = true;
+    else if (a === "--json") out.json = true;
+    else if (a === "--list") out.list = true;
+    else if (a === "--no-banner") out.noBanner = true;
+    else if (a === "--lang") out.lang = args[++i];
+    else if (a.startsWith("--lang=")) out.lang = a.slice(7);
+    else if (a === "--scope") out.scope = args[++i];
+    else if (a.startsWith("--scope=")) out.scope = a.slice(8);
+    // Repeatable, matching orcadub: --platform claude --platform codex.
+    // A comma-separated list is also accepted because people type it anyway.
+    else if (a === "--platform" || a === "--platforms") pushPlatforms(out, args[++i]);
+    else if (a.startsWith("--platform=")) pushPlatforms(out, a.slice(11));
+    else if (a.startsWith("--platforms=")) pushPlatforms(out, a.slice(12));
+    else if (a.startsWith("-")) die(t("common.unknownOption", a), t("common.unknownOptionHint"));
+    else out._.push(a);
+  }
+  return out;
+}
+
+function pushPlatforms(out, raw) {
+  if (!raw) die(t("common.missingPlatformValue"), t("skill.unknownPlatformHint"));
+  out.platforms ??= [];
+  for (const id of raw.split(",").map((s) => s.trim()).filter(Boolean)) {
+    if (!out.platforms.includes(id)) out.platforms.push(id);
+  }
+}
+
+async function main() {
+  const argv = parse(process.argv.slice(2));
+
+  if (argv.lang) {
+    try {
+      setLanguage(parseLanguage(argv.lang));
+    } catch {
+      // Reported in the locale-detected language — the flag was wrong, not the
+      // user's locale, so their own language is still the right one to use.
+      die(t("common.unknownLanguage", argv.lang), t("common.unknownLanguageHint"));
+    }
+  }
+
+  if (argv.help) return usage();
+  if (argv.version) {
+    const pkg = JSON.parse(fs.readFileSync(path.join(PKG_ROOT, "package.json"), "utf8"));
+    return say(pkg.version);
+  }
+
+  ASSUME_YES = Boolean(argv.yes);
+
+  let cmd = argv._[0];
+  const guided = !cmd || (cmd === "skill" && argv._[1] !== "list" && !argv.list);
+
+  // The wordmark and the language screen belong to the guided flows only.
+  // Putting them in front of `doctor` would just be noise on a diagnostic.
+  if (guided) {
+    showBanner(argv);
+    await askLanguage(argv);
+  }
+
+  if (!cmd) {
+    const state = repoState();
+    cmd = await select(
+      `${t("menu.question")}${state.installed ? dim(t("menu.alreadyInstalled")) : ""}`,
+      [
+        { label: t("menu.install"), value: "init", recommended: !state.installed },
+        { label: t("menu.reconfigure"), value: "reconfigure", recommended: state.installed },
+        { label: t("menu.doctor"), value: "doctor" },
+        { label: t("menu.skill", SKILL_PLATFORMS.length), value: "skill" },
+        { label: t("menu.uninstall"), value: "uninstall" },
+      ],
+      { defaultIndex: state.installed ? 1 : 0 },
+    );
+  }
+
+  switch (cmd) {
+    case "init":
+    case "install": return cmdInit(argv);
+    case "reconfigure":
+    case "config": return cmdReconfigure(argv);
+    case "doctor":
+    case "check": return cmdDoctor();
+    case "uninstall":
+    case "remove": return cmdUninstall();
+    case "skill": {
+      // `skill`, `skill install`, `skill list` — the sub-verb is optional so the
+      // bare form keeps working for anyone who learned it before `list` existed.
+      const sub = argv._[1];
+      if (sub === "list" || sub === "platforms" || argv.list) return cmdListPlatforms(argv);
+      if (sub && sub !== "install") die(t("common.unknownCommand", `skill ${sub}`), "skill install | skill list");
+      return cmdSkill(argv);
+    }
+    default:
+      usage();
+      die(t("common.unknownCommand", cmd));
+  }
+}
+
+// Only run when invoked as a program. Importing this file (the test suite does)
+// must not touch the filesystem or open a readline interface.
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  main()
+    .catch((e) => die(e?.message || String(e)))
+    .finally(closeUi);
+}

--- a/bin/platforms.mjs
+++ b/bin/platforms.mjs
@@ -1,0 +1,222 @@
+// Agent Skill platform catalog, ported from orcadub-mcp-server so both Orca
+// products install skills to the same places under the same IDs. Keep the
+// entries, their order, and their IDs in sync with
+// `internal/skill_installer.go` there — a user who runs both installers should
+// not have to learn two names for the same editor.
+//
+// Layout rule: every platform's skill lives at
+//   <base>/<root>/skills/<skill-name>/
+// where <base> is the project directory or the user's home, and <root> is the
+// platform's project or global root.
+//
+// Detection is deliberately conservative — a false positive preselects a
+// platform the user does not have and scatters files into directories they
+// never asked for. Three signals, in order: a project marker, a home marker,
+// then an executable on PATH.
+//
+//   detectionPaths: undefined  -> use [projectRoot] as the project marker
+//   detectionPaths: []         -> project detection disabled for this platform
+
+import fs from "node:fs";
+import path from "node:path";
+
+export const SKILL_PLATFORMS = Object.freeze([
+  {
+    id: "claude",
+    name: "Claude Code",
+    projectRoot: ".claude",
+    globalRoot: ".claude",
+    globalDetectionPaths: [".claude"],
+    executables: ["claude"],
+  },
+  { id: "cursor", name: "Cursor", projectRoot: ".cursor", globalRoot: ".cursor" },
+  {
+    id: "codex",
+    name: "Codex",
+    projectRoot: ".agents",
+    globalRoot: ".agents",
+    // Codex reads skills from `.agents`, but `.agents` is a shared convention —
+    // several hosts write there. Detect on `.codex`, which is Codex-specific.
+    detectionPaths: [".codex"],
+    globalDetectionPaths: [".codex"],
+    executables: ["codex"],
+  },
+  { id: "opencode", name: "OpenCode", projectRoot: ".opencode", globalRoot: ".config/opencode" },
+  { id: "windsurf", name: "Windsurf", projectRoot: ".windsurf", globalRoot: ".windsurf" },
+  { id: "cline", name: "Cline", projectRoot: ".cline", globalRoot: ".cline" },
+  { id: "roocode", name: "RooCode", projectRoot: ".roo", globalRoot: ".roo" },
+  { id: "continue", name: "Continue", projectRoot: ".continue", globalRoot: ".continue" },
+  {
+    id: "github-copilot",
+    name: "GitHub Copilot",
+    projectRoot: ".github",
+    globalRoot: ".github",
+    // `.github` exists in almost every repo, so it cannot be the marker —
+    // it would preselect Copilot for everyone. Require a Copilot-specific file.
+    detectionPaths: [
+      ".github/copilot-instructions.md",
+      ".github/instructions",
+      ".github/prompts",
+      ".github/skills",
+    ],
+  },
+  { id: "gemini", name: "Gemini CLI", projectRoot: ".gemini", globalRoot: ".gemini" },
+  { id: "amazon-q", name: "Amazon Q Developer", projectRoot: ".amazonq", globalRoot: ".amazonq" },
+  { id: "qwen", name: "Qwen Code", projectRoot: ".qwen", globalRoot: ".qwen" },
+  { id: "kilocode", name: "Kilo Code", projectRoot: ".kilocode", globalRoot: ".kilocode" },
+  { id: "auggie", name: "Auggie (Augment CLI)", projectRoot: ".augment", globalRoot: ".augment" },
+  { id: "kimicode", name: "Kimi Code", projectRoot: ".kimi-code", globalRoot: ".kimi-code" },
+  { id: "kiro", name: "Kiro", projectRoot: ".kiro", globalRoot: ".kiro" },
+  { id: "lingma", name: "Lingma", projectRoot: ".lingma", globalRoot: ".lingma" },
+  { id: "junie", name: "Junie", projectRoot: ".junie", globalRoot: ".junie" },
+  { id: "codebuddy", name: "CodeBuddy Code", projectRoot: ".codebuddy", globalRoot: ".codebuddy" },
+  { id: "costrict", name: "CoStrict", projectRoot: ".cospec", globalRoot: ".cospec" },
+  { id: "crush", name: "Crush", projectRoot: ".crush", globalRoot: ".crush" },
+  { id: "factory", name: "Factory Droid", projectRoot: ".factory", globalRoot: ".factory" },
+  { id: "iflow", name: "iFlow", projectRoot: ".iflow", globalRoot: ".iflow" },
+  { id: "pi", name: "Pi", projectRoot: ".pi", globalRoot: ".pi/agent" },
+  { id: "qoder", name: "Qoder", projectRoot: ".qoder", globalRoot: ".qoder" },
+  {
+    id: "antigravity",
+    name: "Antigravity",
+    projectRoot: ".agents",
+    globalRoot: ".gemini/antigravity",
+    detectionPaths: [],
+  },
+  {
+    id: "antigravity2",
+    name: "Antigravity 2.0",
+    projectRoot: ".agents",
+    globalRoot: ".gemini/config",
+    detectionPaths: [],
+  },
+  { id: "bob", name: "Bob Shell", projectRoot: ".bob", globalRoot: ".bob" },
+  { id: "forgecode", name: "ForgeCode", projectRoot: ".forge", globalRoot: ".forge" },
+  { id: "trae", name: "Trae", projectRoot: ".trae", globalRoot: ".trae" },
+  { id: "trae-cn", name: "Trae CN", projectRoot: ".trae-cn", globalRoot: ".trae-cn" },
+  { id: "zcode", name: "ZCode", projectRoot: ".zcode", globalRoot: ".zcode" },
+  { id: "mimocode", name: "MimoCode", projectRoot: ".mimocode", globalRoot: ".config/mimocode" },
+  {
+    id: "hermes",
+    name: "Hermes",
+    projectRoot: ".hermes",
+    globalRoot: ".hermes",
+    globalDetectionPaths: [".hermes"],
+    executables: ["hermes"],
+  },
+  {
+    id: "openclaw",
+    name: "OpenClaw",
+    projectRoot: ".",
+    globalRoot: ".openclaw",
+    // Its project root is the bare workspace `skills/` directory, which is far
+    // too generic to detect on. Fall back to the home marker and the binary.
+    detectionPaths: [],
+    globalDetectionPaths: [".openclaw"],
+    executables: ["openclaw"],
+  },
+  {
+    id: "command-code",
+    name: "Command Code",
+    projectRoot: ".commandcode",
+    globalRoot: ".commandcode",
+    globalDetectionPaths: [".commandcode"],
+    // Deliberately no executable check: its binary is `cmd`, which is a
+    // standard Windows executable and would match on every Windows machine.
+  },
+]);
+
+// Shown first in the picker when nothing is detected, so the list opens on
+// names most users recognize instead of 36 rows of alphabet soup.
+export const POPULAR_PLATFORM_IDS = Object.freeze([
+  "claude",
+  "codex",
+  "cursor",
+  "github-copilot",
+  "gemini",
+  "opencode",
+  "windsurf",
+]);
+
+export function findPlatform(id) {
+  return SKILL_PLATFORMS.find((p) => p.id === id);
+}
+
+const exists = (p) => {
+  try {
+    fs.statSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Returns the IDs of platforms that appear to be in use, in catalog order.
+ * `lookPath` resolves an executable name to a path (or throws / returns null).
+ */
+export function detectPlatforms(projectDir, homeDir, lookPath) {
+  const detected = [];
+
+  for (const platform of SKILL_PLATFORMS) {
+    const projectMarkers = platform.detectionPaths ?? [platform.projectRoot];
+
+    if (projectDir && projectMarkers.some((m) => exists(path.join(projectDir, m)))) {
+      detected.push(platform.id);
+      continue;
+    }
+    if (homeDir && (platform.globalDetectionPaths ?? []).some((m) => exists(path.join(homeDir, m)))) {
+      detected.push(platform.id);
+      continue;
+    }
+    if (lookPath && (platform.executables ?? []).some((exe) => Boolean(lookPath(exe)))) {
+      detected.push(platform.id);
+    }
+  }
+
+  return detected;
+}
+
+/**
+ * Maps platform IDs to destination directories, collapsing platforms that
+ * resolve to the same path into one target.
+ *
+ * This matters: Codex, Antigravity, and Antigravity 2.0 all use `.agents` for
+ * project installs. Without the merge, one install would be reported three
+ * times and — worse — the second write would see the first one's output and
+ * report a spurious conflict.
+ */
+export function resolveTargets({ platformIds, scope, projectDir, homeDir, skillName }) {
+  if (scope !== "project" && scope !== "global") {
+    throw new Error(`unknown install scope "${scope}" (use project or global)`);
+  }
+
+  const targets = [];
+  const byPath = new Map();
+
+  for (const id of platformIds) {
+    const platform = findPlatform(id);
+    if (!platform) throw new Error(`unknown platform "${id}"`);
+
+    const base = scope === "global" ? homeDir : projectDir;
+    const root = scope === "global" ? platform.globalRoot : platform.projectRoot;
+    if (!base || !path.isAbsolute(base)) {
+      throw new Error(`${scope} install base must be an absolute path: "${base}"`);
+    }
+
+    const dir = path.normalize(path.join(base, root, "skills", skillName));
+
+    const existing = byPath.get(dir);
+    if (existing) {
+      existing.platformIds.push(platform.id);
+      existing.platformNames.push(platform.name);
+      continue;
+    }
+
+    const target = { platformIds: [platform.id], platformNames: [platform.name], path: dir };
+    byPath.set(dir, target);
+    targets.push(target);
+  }
+
+  return targets;
+}

--- a/bin/skill-tree.mjs
+++ b/bin/skill-tree.mjs
@@ -1,0 +1,130 @@
+// Installing a skill *directory* into a platform's skills root.
+//
+// orcadub ships a single SKILL.md, so it can install with one atomic
+// link-or-rename. This skill is a tree (SKILL.md + references/ + assets/), so
+// the unit of comparison is the whole tree: a partially-updated skill — new
+// SKILL.md pointing at a reference file from the previous version — is worse
+// than either version alone, because the agent follows a link into stale
+// guidance and has no way to notice.
+//
+// Statuses match orcadub's so both installers report the same words:
+//   installed | updated | unchanged | conflict | error
+//
+// An existing tree that differs is NEVER overwritten without `force`. A user
+// may have edited the skill; silently reverting their edits is the one failure
+// mode an installer cannot apologize its way out of.
+
+import fs from "node:fs";
+import path from "node:path";
+
+export const STATUS = Object.freeze({
+  installed: "installed",
+  updated: "updated",
+  unchanged: "unchanged",
+  conflict: "conflict",
+  error: "error",
+});
+
+/** Reads a directory into a Map of posix-relative path -> Buffer. */
+export function readTree(root) {
+  const files = new Map();
+
+  const walk = (dir, prefix) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const abs = path.join(dir, entry.name);
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) walk(abs, rel);
+      else if (entry.isFile()) files.set(rel, fs.readFileSync(abs));
+    }
+  };
+
+  walk(root, "");
+  return files;
+}
+
+export function treesEqual(a, b) {
+  if (a.size !== b.size) return false;
+  for (const [rel, buf] of a) {
+    const other = b.get(rel);
+    if (!other || !buf.equals(other)) return false;
+  }
+  return true;
+}
+
+// Same-directory temp file + rename: the destination is either the old content
+// or the new content, never a half-written file an agent might read mid-write.
+function writeFileAtomic(dest, data, { noClobber = false } = {}) {
+  const dir = path.dirname(dest);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const tmp = path.join(dir, `.${path.basename(dest)}-${process.pid}-${counter++}`);
+  try {
+    fs.writeFileSync(tmp, data, { mode: 0o644 });
+    if (noClobber) {
+      // link() fails with EEXIST rather than clobbering, which closes the gap
+      // between "we checked and it was absent" and "we wrote".
+      fs.linkSync(tmp, dest);
+    } else {
+      fs.renameSync(tmp, dest);
+    }
+  } finally {
+    try { fs.rmSync(tmp, { force: true }); } catch { /* the rename already consumed it */ }
+  }
+}
+let counter = 0;
+
+/**
+ * Installs `source` (a directory) at `dest`, returning one of STATUS.
+ * Never throws for the ordinary conflict case — that is a status, not an error.
+ */
+export function installTree(source, dest, { force = false } = {}) {
+  const wanted = readTree(source);
+  if (wanted.size === 0) throw new Error(`skill source is empty: ${source}`);
+
+  const destExists = fs.existsSync(dest);
+
+  if (destExists) {
+    const current = readTree(dest);
+    if (treesEqual(wanted, current)) return STATUS.unchanged;
+    if (!force) return STATUS.conflict;
+
+    for (const [rel, data] of wanted) writeFileAtomic(path.join(dest, rel), data);
+
+    // Drop files the new version no longer ships, so a stale reference cannot
+    // outlive the SKILL.md that used to point at it.
+    for (const rel of current.keys()) {
+      if (!wanted.has(rel)) fs.rmSync(path.join(dest, rel), { force: true });
+    }
+    pruneEmptyDirs(dest);
+    return STATUS.updated;
+  }
+
+  let clobbered = false;
+  for (const [rel, data] of wanted) {
+    try {
+      writeFileAtomic(path.join(dest, rel), data, { noClobber: true });
+    } catch (e) {
+      if (e.code !== "EEXIST") throw e;
+      // Something created the tree between our check and this write. Re-read and
+      // let the normal comparison decide instead of racing it.
+      clobbered = true;
+      break;
+    }
+  }
+  if (!clobbered) return STATUS.installed;
+
+  const current = readTree(dest);
+  if (treesEqual(wanted, current)) return STATUS.unchanged;
+  if (!force) return STATUS.conflict;
+  for (const [rel, data] of wanted) writeFileAtomic(path.join(dest, rel), data);
+  return STATUS.updated;
+}
+
+function pruneEmptyDirs(root) {
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const abs = path.join(root, entry.name);
+    pruneEmptyDirs(abs);
+    if (fs.readdirSync(abs).length === 0) fs.rmdirSync(abs);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "orcacode-review",
+  "version": "1.0.0",
+  "description": "One-command installer for OrcaCode Review — AI pull-request review powered by OrcaRouter.",
+  "bin": {
+    "orcacode-review": "bin/orcacode-review.mjs"
+  },
+  "type": "module",
+  "engines": {
+    "node": ">=18.17"
+  },
+  "files": [
+    "bin/",
+    "skills/",
+    "NOTICE"
+  ],
+  "scripts": {
+    "test": "node --test scripts/*.test.mjs"
+  },
+  "keywords": [
+    "code-review",
+    "ai",
+    "github-actions",
+    "pull-request",
+    "orcarouter",
+    "claude-code",
+    "skill"
+  ],
+  "homepage": "https://www.orcarouter.ai/code-review",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Continuum-AI-Corp/orca-code-review.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Continuum-AI-Corp/orca-code-review/issues"
+  },
+  "author": "Continuum-AI-Corp",
+  "license": "MIT"
+}

--- a/scripts/i18n.test.mjs
+++ b/scripts/i18n.test.mjs
@@ -1,0 +1,172 @@
+// Tests for the zh/en string table and the ORCA CODE REVIEW wordmark.
+//
+// The failure this guards against is not a crash — it is a Chinese session
+// that silently drops to English, or worse, prints a raw key like
+// "doctor.gateMissingFix" where a sentence should be. Both look like the tool
+// is broken, and neither shows up in any other test.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { LANGUAGES, TABLES, makeT, parseLanguage, detectLanguage } from "../bin/i18n.mjs";
+import { bannerRows, bannerWidth, renderBanner } from "../bin/banner.mjs";
+
+// Walks a nested string table into a flat list of dotted keys.
+function flatten(node, prefix = "") {
+  const keys = [];
+  for (const [k, v] of Object.entries(node)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === "object" && !Array.isArray(v)) keys.push(...flatten(v, key));
+    else keys.push(key);
+  }
+  return keys;
+}
+
+const lookup = (table, key) => key.split(".").reduce((n, p) => n?.[p], table);
+
+// ------------------------------------------------------------------- table ---
+
+test("Chinese covers every English key", () => {
+  // A missing key falls back to English, which reads as a half-translated tool.
+  const missing = flatten(TABLES.en).filter((k) => lookup(TABLES.zh, k) === undefined);
+  assert.deepEqual(missing, [], `untranslated keys: ${missing.join(", ")}`);
+});
+
+test("Chinese adds no keys English lacks", () => {
+  // A zh-only key is dead weight: nothing reads it, and it hides the fact that
+  // the English side was never written.
+  const extra = flatten(TABLES.zh).filter((k) => lookup(TABLES.en, k) === undefined);
+  assert.deepEqual(extra, [], `zh-only keys: ${extra.join(", ")}`);
+});
+
+test("a key is a function in both languages or neither", () => {
+  // A parameterized English string paired with a plain Chinese one silently
+  // drops the argument — the branch name or count just vanishes.
+  const mismatched = flatten(TABLES.en).filter(
+    (k) => typeof lookup(TABLES.en, k) !== typeof lookup(TABLES.zh, k),
+  );
+  assert.deepEqual(mismatched, [], `arity mismatch: ${mismatched.join(", ")}`);
+});
+
+test("parameterized strings take the same argument count in both languages", () => {
+  for (const key of flatten(TABLES.en)) {
+    const en = lookup(TABLES.en, key);
+    if (typeof en !== "function") continue;
+    assert.equal(lookup(TABLES.zh, key).length, en.length, `${key}: differing arity`);
+  }
+});
+
+test("every string is non-empty in both languages", () => {
+  for (const lang of LANGUAGES) {
+    for (const key of flatten(TABLES[lang])) {
+      const value = lookup(TABLES[lang], key);
+      const rendered = typeof value === "function"
+        ? value(...Array.from({ length: value.length }, (_, i) => `arg${i}`))
+        : value;
+      assert.ok(String(rendered).trim().length > 0, `${lang}.${key} is empty`);
+    }
+  }
+});
+
+test("commands and flags survive translation", () => {
+  // A reader of the Chinese output still has to type these. Translating or
+  // dropping one produces an instruction that cannot be followed.
+  //
+  // The invariant is derived from English rather than hardcoded: a literal the
+  // English table never mentions proves nothing about the Chinese one.
+  const render = (lang) =>
+    JSON.stringify(
+      flatten(TABLES[lang]).map((k) => {
+        const v = lookup(TABLES[lang], k);
+        return typeof v === "function" ? v("A", "B") : v;
+      }),
+    );
+  const en = render("en");
+  const zh = render("zh");
+
+  const candidates = [
+    "--force", "--platform", "--scope", "--yes", "--help", "--lang",
+    "gh secret set", "gh auth login", "gh run view",
+    "pull_request_target", "auto_review", "ready_for_review", "auto-review-authors",
+    "npx orcacode-review", "orcacode-review skill list", "/orcacode-review",
+  ];
+  const present = candidates.filter((literal) => en.includes(literal));
+  assert.ok(present.length >= 10, "the English table stopped mentioning the literals this test guards");
+  for (const literal of present) assert.ok(zh.includes(literal), `zh table lost the literal: ${literal}`);
+});
+
+// ----------------------------------------------------------------- selection ---
+
+test("makeT falls back to English for an unknown language", () => {
+  assert.equal(makeT("de")("common.recommended"), TABLES.en.common.recommended);
+});
+
+test("makeT returns the key rather than throwing on an unknown key", () => {
+  assert.equal(makeT("en")("no.such.key"), "no.such.key");
+});
+
+test("makeT applies arguments to parameterized strings", () => {
+  assert.match(makeT("zh")("doctor.notOnBase", "main"), /main/);
+  assert.match(makeT("en")("doctor.notOnBase", "main"), /main/);
+});
+
+test("parseLanguage accepts zh/en in any casing and rejects the rest", () => {
+  assert.equal(parseLanguage(" ZH "), "zh");
+  assert.equal(parseLanguage("en"), "en");
+  assert.throws(() => parseLanguage("fr"), /unknown language/);
+});
+
+test("locale detection maps the Chinese locales and defaults to English", () => {
+  assert.equal(detectLanguage({ LANG: "zh_CN.UTF-8" }), "zh");
+  assert.equal(detectLanguage({ LC_ALL: "zh_TW.UTF-8" }), "en"); // Traditional is not translated
+  assert.equal(detectLanguage({ LANG: "en_US.UTF-8" }), "en");
+  assert.equal(detectLanguage({}), "en");
+});
+
+test("LC_ALL outranks LANG, and ORCACODE_LANG outranks both", () => {
+  assert.equal(detectLanguage({ LC_ALL: "en_US.UTF-8", LANG: "zh_CN.UTF-8" }), "en");
+  assert.equal(detectLanguage({ ORCACODE_LANG: "zh", LANG: "en_US.UTF-8" }), "zh");
+});
+
+test("a malformed ORCACODE_LANG falls through to the locale instead of failing", () => {
+  assert.equal(detectLanguage({ ORCACODE_LANG: "klingon", LANG: "zh_CN.UTF-8" }), "zh");
+});
+
+// -------------------------------------------------------------------- banner ---
+
+test("the wordmark fits a standard 80-column terminal", () => {
+  assert.ok(bannerWidth() <= 80, `wordmark is ${bannerWidth()} columns`);
+});
+
+test("every wordmark row is the same width once color is stripped", () => {
+  const rows = bannerRows(false);
+  assert.ok(rows.length > 0);
+  // Rows are padded to center the shorter line, so trailing space may differ;
+  // what must hold is that nothing exceeds the declared width.
+  for (const row of rows) assert.ok(row.length <= bannerWidth(), `row too wide: ${row.length}`);
+});
+
+test("the plain wordmark carries no escape sequences", () => {
+  for (const row of bannerRows(false)) assert.doesNotMatch(row, /\x1b\[/);
+});
+
+test("the colored wordmark opens and closes every sequence", () => {
+  for (const row of bannerRows(true)) {
+    assert.match(row, /^\x1b\[9[46]m/);
+    assert.match(row, /\x1b\[0m$/);
+  }
+});
+
+test("a narrow terminal gets a one-line title instead of a wrapped wordmark", () => {
+  // A wrapped wordmark reads as corruption, which is worse than no wordmark.
+  let out = "";
+  renderBanner((s) => { out += s; }, { color: false, columns: 40 });
+  assert.equal(out.trim(), "Orca Code Review");
+  assert.equal(out.split("\n").filter(Boolean).length, 1);
+});
+
+test("a wide terminal gets the full wordmark", () => {
+  let out = "";
+  renderBanner((s) => { out += s; }, { color: false, columns: 120 });
+  assert.equal(out.split("\n").filter(Boolean).length, bannerRows(false).length);
+});

--- a/scripts/installer.test.mjs
+++ b/scripts/installer.test.mjs
@@ -1,0 +1,98 @@
+// Tests for the `npx orcacode-review` workflow renderer.
+//
+// The renderer decides what a consumer's CI actually does, so the two
+// properties worth pinning are: (1) it only writes inputs that differ from
+// their documented default — a file that echoes defaults implies control it
+// does not have when the dashboard is authoritative; and (2) what it writes is
+// readable back by `reconfigure`, so the round trip cannot silently drift.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULTS,
+  renderWorkflow,
+  parseOverrides,
+} from "../bin/orcacode-review.mjs";
+
+const withBlock = (yaml) =>
+  yaml.slice(yaml.indexOf("        with:")).split("\n").slice(1).filter((l) => l.trim());
+
+test("all-default config writes only the api key", () => {
+  const yaml = renderWorkflow({ ...DEFAULTS });
+  const lines = withBlock(yaml);
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /orcarouter-api-key: \$\{\{ secrets\.ORCAROUTER_API_KEY \}\}/);
+});
+
+test("non-default inputs are written, defaults are not", () => {
+  const yaml = renderWorkflow({
+    settings: "false",
+    "block-on": "P0",
+    "on-oversized-diff": "fail", // default — must be omitted
+    "auto-review-authors": "OWNER,MEMBER",
+  });
+  assert.match(yaml, /^\s+settings: "false"/m);
+  assert.match(yaml, /^\s+block-on: "P0"/m);
+  assert.match(yaml, /^\s+auto-review-authors: "OWNER,MEMBER"/m);
+  assert.doesNotMatch(yaml, /^\s+on-oversized-diff:/m);
+});
+
+test('block-on "" (never block) is written, not dropped as falsy', () => {
+  // An explicit empty string is a deliberate "none", not an absent value. If it
+  // were dropped, a user who chose comment-only mode would silently get the
+  // P0,P1 default and their merges would start failing.
+  const yaml = renderWorkflow({ ...DEFAULTS, "block-on": "" });
+  assert.match(yaml, /^\s+block-on: ""/m);
+});
+
+test("undefined inputs are skipped", () => {
+  const yaml = renderWorkflow({ ...DEFAULTS, "auto-review-authors": undefined });
+  assert.doesNotMatch(yaml, /auto-review-authors/);
+});
+
+test("the generated workflow keeps the security-critical scaffolding", () => {
+  const yaml = renderWorkflow({ ...DEFAULTS });
+  // pull_request_target is what lets a fork PR be reviewed at all.
+  assert.match(yaml, /pull_request_target:/);
+  // The author-association gate is what stops a drive-by commenter from
+  // spending paid quota with /orcacode-review.
+  assert.match(yaml, /\["OWNER", "MEMBER", "COLLABORATOR"\]/);
+  // All four command spellings the GitHub App accepts.
+  for (const cmd of ["/orcacode-review", "/orcacode review", "@orcacode-review", "@orcacode review"]) {
+    assert.ok(yaml.includes(`'${cmd}'`), `missing command spelling: ${cmd}`);
+  }
+  assert.match(yaml, /pull-requests: write/);
+  assert.match(yaml, /issues: write/);
+});
+
+test("render -> parse round-trips every input", () => {
+  const cfg = {
+    settings: "false",
+    "block-on": "",
+    "on-oversized-diff": "pass",
+    "auto-review-authors": "OWNER,MEMBER,COLLABORATOR,CONTRIBUTOR",
+  };
+  assert.deepEqual(parseOverrides(renderWorkflow(cfg)), cfg);
+});
+
+test("parsing a defaults-only workflow reports the defaults", () => {
+  assert.deepEqual(parseOverrides(renderWorkflow({ ...DEFAULTS })), { ...DEFAULTS });
+});
+
+test("commented-out example inputs are not read as overrides", () => {
+  // The shipped template documents optional inputs as comments. Treating one as
+  // a real value would make `reconfigure` show a change the file never had.
+  const text = [
+    "        with:",
+    "          orcarouter-api-key: ${{ secrets.ORCAROUTER_API_KEY }}",
+    '          # settings: "false"',
+    '          # block-on: "P0"',
+  ].join("\n");
+  assert.deepEqual(parseOverrides(text), { ...DEFAULTS });
+});
+
+test("a trailing comment on a real input does not leak into the value", () => {
+  const text = '          block-on: "P0"  # severities that fail the check\n';
+  assert.equal(parseOverrides(text)["block-on"], "P0");
+});

--- a/scripts/platforms.test.mjs
+++ b/scripts/platforms.test.mjs
@@ -1,0 +1,273 @@
+// Tests for the agent-platform catalog and the skill-tree installer.
+//
+// Two classes of bug are worth guarding against here. Catalog bugs are silent:
+// a duplicate id or a too-generic detection marker scatters files into
+// directories the user never asked about, and nothing errors. Installer bugs
+// are destructive: overwriting a skill somebody edited, or leaving a tree
+// half-updated so the SKILL.md points at a reference file from a prior version.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  SKILL_PLATFORMS,
+  POPULAR_PLATFORM_IDS,
+  findPlatform,
+  detectPlatforms,
+  resolveTargets,
+} from "../bin/platforms.mjs";
+import { installTree, readTree, treesEqual, STATUS } from "../bin/skill-tree.mjs";
+
+const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), "ocr-plat-"));
+
+const writeTree = (root, files) => {
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+  }
+  return root;
+};
+
+// ------------------------------------------------------------------ catalog ---
+
+test("the catalog matches the orcadub platform count", () => {
+  // Both Orca installers ship the same catalog. If this number moves, the other
+  // repo and the README platform count move with it.
+  assert.equal(SKILL_PLATFORMS.length, 36);
+});
+
+test("ids and display names are unique", () => {
+  assert.equal(new Set(SKILL_PLATFORMS.map((p) => p.id)).size, SKILL_PLATFORMS.length);
+  assert.equal(new Set(SKILL_PLATFORMS.map((p) => p.name)).size, SKILL_PLATFORMS.length);
+});
+
+test("every platform declares both roots", () => {
+  for (const p of SKILL_PLATFORMS) {
+    assert.ok(p.projectRoot, `${p.id} has no projectRoot`);
+    assert.ok(p.globalRoot, `${p.id} has no globalRoot`);
+    assert.doesNotMatch(p.projectRoot, /^\//, `${p.id} projectRoot must be relative`);
+    assert.doesNotMatch(p.globalRoot, /^\//, `${p.id} globalRoot must be relative`);
+  }
+});
+
+test("every popular id exists in the catalog", () => {
+  for (const id of POPULAR_PLATFORM_IDS) assert.ok(findPlatform(id), `unknown popular id: ${id}`);
+});
+
+test("platforms with a too-generic root do not detect on that root", () => {
+  // `.github` is in nearly every repo and `.` is every directory. Detecting on
+  // those would preselect Copilot and OpenClaw for everyone on earth.
+  assert.deepEqual(findPlatform("openclaw").detectionPaths, []);
+  const copilot = findPlatform("github-copilot");
+  assert.ok(copilot.detectionPaths.length > 0);
+  assert.ok(!copilot.detectionPaths.includes(".github"));
+});
+
+test("Command Code does not detect on its `cmd` executable", () => {
+  // `cmd` is a stock Windows binary — it would match on every Windows machine.
+  assert.ok(!(findPlatform("command-code").executables ?? []).includes("cmd"));
+});
+
+// ---------------------------------------------------------------- detection ---
+
+test("a project marker directory detects its platform", () => {
+  const dir = tmp();
+  fs.mkdirSync(path.join(dir, ".cursor"));
+  assert.deepEqual(detectPlatforms(dir, "", null), ["cursor"]);
+});
+
+test("Codex detects on .codex, not on the .agents directory it writes to", () => {
+  const withAgents = tmp();
+  fs.mkdirSync(path.join(withAgents, ".agents"));
+  assert.ok(!detectPlatforms(withAgents, "", null).includes("codex"));
+
+  const withCodex = tmp();
+  fs.mkdirSync(path.join(withCodex, ".codex"));
+  assert.ok(detectPlatforms(withCodex, "", null).includes("codex"));
+});
+
+test("a bare .github directory does not detect GitHub Copilot", () => {
+  const dir = tmp();
+  fs.mkdirSync(path.join(dir, ".github", "workflows"), { recursive: true });
+  assert.ok(!detectPlatforms(dir, "", null).includes("github-copilot"));
+
+  fs.writeFileSync(path.join(dir, ".github", "copilot-instructions.md"), "x");
+  assert.ok(detectPlatforms(dir, "", null).includes("github-copilot"));
+});
+
+test("a home marker detects a platform absent from the project", () => {
+  const home = tmp();
+  fs.mkdirSync(path.join(home, ".claude"));
+  assert.ok(detectPlatforms(tmp(), home, null).includes("claude"));
+});
+
+test("an executable on PATH detects a platform with no markers", () => {
+  const found = detectPlatforms(tmp(), tmp(), (exe) => exe === "hermes");
+  assert.deepEqual(found, ["hermes"]);
+});
+
+test("detection returns catalog order and never duplicates", () => {
+  const dir = tmp();
+  for (const marker of [".claude", ".cursor", ".codex"]) fs.mkdirSync(path.join(dir, marker));
+  // Same platforms also visible via home + PATH — each must still appear once.
+  const found = detectPlatforms(dir, dir, (exe) => exe === "claude");
+  assert.deepEqual(found, ["claude", "cursor", "codex"]);
+});
+
+// ----------------------------------------------------------------- targets ---
+
+test("platforms sharing a root collapse into one target", () => {
+  // Codex, Antigravity, and Antigravity 2.0 all use .agents for project
+  // installs. Without the merge, the second write would see the first one's
+  // output and report a bogus conflict.
+  const targets = resolveTargets({
+    platformIds: ["codex", "antigravity", "antigravity2"],
+    scope: "project",
+    projectDir: "/repo",
+    homeDir: "/home/u",
+    skillName: "s",
+  });
+  assert.equal(targets.length, 1);
+  assert.deepEqual(targets[0].platformIds, ["codex", "antigravity", "antigravity2"]);
+  assert.equal(targets[0].path, path.normalize("/repo/.agents/skills/s"));
+});
+
+test("the same platforms stay separate under global scope", () => {
+  // Their global roots differ (.agents, .gemini/antigravity, .gemini/config),
+  // so the project-scope merge must not be assumed to hold.
+  const targets = resolveTargets({
+    platformIds: ["codex", "antigravity", "antigravity2"],
+    scope: "global",
+    projectDir: "/repo",
+    homeDir: "/home/u",
+    skillName: "s",
+  });
+  assert.equal(targets.length, 3);
+});
+
+test("global scope uses the global root, which can differ from the project root", () => {
+  const [target] = resolveTargets({
+    platformIds: ["opencode"],
+    scope: "global",
+    projectDir: "/repo",
+    homeDir: "/home/u",
+    skillName: "s",
+  });
+  assert.equal(target.path, path.normalize("/home/u/.config/opencode/skills/s"));
+});
+
+test("OpenClaw's project root is the bare workspace directory", () => {
+  const [target] = resolveTargets({
+    platformIds: ["openclaw"],
+    scope: "project",
+    projectDir: "/repo",
+    homeDir: "/home/u",
+    skillName: "s",
+  });
+  assert.equal(target.path, path.normalize("/repo/skills/s"));
+});
+
+test("unknown platform, unknown scope, and relative base are all rejected", () => {
+  const base = { scope: "project", projectDir: "/repo", homeDir: "/home/u", skillName: "s" };
+  assert.throws(() => resolveTargets({ ...base, platformIds: ["nope"] }), /unknown platform/);
+  assert.throws(() => resolveTargets({ ...base, platformIds: ["claude"], scope: "user" }), /unknown install scope/);
+  assert.throws(
+    () => resolveTargets({ ...base, platformIds: ["claude"], projectDir: "relative" }),
+    /must be an absolute path/,
+  );
+});
+
+test("every catalog platform resolves to a path under both scopes", () => {
+  for (const p of SKILL_PLATFORMS) {
+    for (const scope of ["project", "global"]) {
+      const [t] = resolveTargets({
+        platformIds: [p.id],
+        scope,
+        projectDir: "/repo",
+        homeDir: "/home/u",
+        skillName: "s",
+      });
+      assert.ok(t.path.endsWith(path.join("skills", "s")), `${p.id}/${scope}: ${t.path}`);
+    }
+  }
+});
+
+// --------------------------------------------------------------- tree install ---
+
+const SOURCE = { "SKILL.md": "v1\n", "references/a.md": "A\n" };
+
+test("a fresh destination reports installed and writes the whole tree", () => {
+  const src = writeTree(tmp(), SOURCE);
+  const dest = path.join(tmp(), "skills", "x");
+  assert.equal(installTree(src, dest), STATUS.installed);
+  assert.ok(treesEqual(readTree(src), readTree(dest)));
+});
+
+test("an identical destination reports unchanged", () => {
+  const src = writeTree(tmp(), SOURCE);
+  const dest = path.join(tmp(), "x");
+  installTree(src, dest);
+  assert.equal(installTree(src, dest), STATUS.unchanged);
+});
+
+test("a differing destination reports conflict and is left untouched", () => {
+  const src = writeTree(tmp(), SOURCE);
+  const dest = writeTree(path.join(tmp(), "x"), { "SKILL.md": "hand-edited\n" });
+  assert.equal(installTree(src, dest), STATUS.conflict);
+  assert.equal(fs.readFileSync(path.join(dest, "SKILL.md"), "utf8"), "hand-edited\n");
+});
+
+test("--force overwrites and reports updated", () => {
+  const src = writeTree(tmp(), SOURCE);
+  const dest = writeTree(path.join(tmp(), "x"), { "SKILL.md": "hand-edited\n" });
+  assert.equal(installTree(src, dest, { force: true }), STATUS.updated);
+  assert.ok(treesEqual(readTree(src), readTree(dest)));
+});
+
+test("a forced update removes files the new version no longer ships", () => {
+  // A leftover reference file outlives the SKILL.md that pointed at it, and the
+  // agent has no way to tell it is reading guidance from a prior version.
+  const src = writeTree(tmp(), SOURCE);
+  const dest = writeTree(path.join(tmp(), "x"), {
+    "SKILL.md": "old\n",
+    "references/gone.md": "stale\n",
+  });
+  assert.equal(installTree(src, dest, { force: true }), STATUS.updated);
+  assert.ok(!fs.existsSync(path.join(dest, "references", "gone.md")));
+  assert.ok(fs.existsSync(path.join(dest, "references", "a.md")));
+});
+
+test("an empty source is an error, not a silent no-op install", () => {
+  assert.throws(() => installTree(tmp(), path.join(tmp(), "x")), /empty/);
+});
+
+test("no temp files survive an install", () => {
+  const src = writeTree(tmp(), SOURCE);
+  const dest = path.join(tmp(), "x");
+  installTree(src, dest);
+  installTree(src, dest, { force: true });
+  const leftovers = readTree(dest);
+  assert.deepEqual([...leftovers.keys()].sort(), ["SKILL.md", "references/a.md"]);
+});
+
+// --------------------------------------------------------------- the shipped skill ---
+
+test("the bundled skill is a valid Agent Skill for every host", () => {
+  // Codex, OpenCode, and Claude Code all require exactly `name` + `description`
+  // in the frontmatter, and `name` must equal the directory name.
+  const dir = new URL("../skills/setup-orca-code-review/", import.meta.url);
+  const text = fs.readFileSync(new URL("SKILL.md", dir), "utf8");
+  const frontmatter = text.match(/^---\n([\s\S]*?)\n---\n/);
+  assert.ok(frontmatter, "SKILL.md has no YAML frontmatter");
+
+  const name = frontmatter[1].match(/^name:\s*(\S+)/m);
+  const description = frontmatter[1].match(/^description:\s*(.+)/m);
+  assert.equal(name?.[1], "setup-orca-code-review");
+  assert.ok(description, "SKILL.md has no description");
+  assert.ok(description[1].length <= 1024, "description exceeds the 1024-char limit hosts enforce");
+  assert.match(name[1], /^[a-z0-9]+(-[a-z0-9]+)*$/, "name must be lowercase with single hyphens");
+});

--- a/skills/setup-orca-code-review/SKILL.md
+++ b/skills/setup-orca-code-review/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: setup-orca-code-review
+description: Install, reconfigure, troubleshoot, or uninstall OrcaCode Review (AI pull-request review powered by OrcaRouter) in a GitHub repository. Use when the user asks to "set up AI code review", "install OrcaCode Review", "add the orca-code-review action", change which severities block merges, fix a review that is not running or not posting, or remove the review workflow.
+---
+
+# OrcaCode Review setup
+
+OrcaCode Review is a GitHub composite action that reviews every pull request with
+an LLM, posts findings as inline comments, and fails a status check when serious
+issues are found. Model selection lives in OrcaRouter, not in the workflow file.
+
+**Severity contract:** `P0` critical / `P1` high → ❌ block. `P2` advisory → 💬 comment.
+
+## Pick the route
+
+Read the user's request and jump straight to the matching section. Do not run the
+install flow on a repo that already has the workflow — go to **Reconfigure** instead.
+
+| The user wants to… | Go to |
+| --- | --- |
+| Add review to a repo for the first time | [Install](#install) |
+| Change blocking rules, diff limits, or where config lives | [Reconfigure](#reconfigure) |
+| Fix reviews that don't run, don't post, or always fail | [Troubleshoot](#troubleshoot) |
+| Remove OrcaCode Review | [Uninstall](#uninstall) |
+
+Run this first in every route — it tells you which one applies:
+
+```bash
+git rev-parse --show-toplevel && \
+  gh repo view --json nameWithOwner,visibility,defaultBranchRef 2>/dev/null; \
+  ls .github/workflows/ 2>/dev/null | grep -i 'orca\|code-review'
+```
+
+If `gh` is missing or unauthenticated, everything still works — you just hand the
+user web URLs instead of running commands. Say so once and move on.
+
+## Install
+
+### 1. Preflight
+
+Confirm all three, and stop with a specific message if any fails:
+
+- Inside a git work tree with a GitHub `origin` remote.
+- No existing OrcaCode workflow (if there is one → **Reconfigure**).
+- Record the repo's `nameWithOwner`, `visibility`, and default branch — later steps need them.
+
+### 2. Ask for the key decisions
+
+Ask these with **one** `AskUserQuestion` call. Include the fourth question **only when
+`visibility` is `PUBLIC`** — it is a spend-control decision that does not exist on a
+private repo, and asking it there is noise.
+
+**Q1 — "Where should review settings live?"** (`settings` input)
+- *OrcaRouter dashboard (recommended)* → `settings: "true"`. Models, review mode,
+  severity rules, and rubric change from the console with no workflow edit. Dashboard
+  values win unless a `with:` input differs from its documented default.
+- *This workflow file* → `settings: "false"`. Skips the dashboard fetch entirely; the
+  YAML is authoritative and nothing server-side can override it. Pick this for repos
+  under change control.
+
+**Q2 — "Which findings should block the merge?"** (`block-on` input)
+- *P0 and P1 (recommended)* → `"P0,P1"`. The default contract.
+- *P0 only* → `"P0"`. Blocks only critical issues; P1 still posts inline.
+- *Nothing — comment only* → `""`. The check always passes. Good for a trial period.
+
+**Q3 — "What happens when a PR's diff is too large to review?"** (`on-oversized-diff`)
+- *Fail the check (recommended)* → `"fail"`. A diff padded past `max-diff-kb` /
+  `max-diff-files` cannot be used to slip past a required merge gate.
+- *Pass with a notice* → `"pass"`. The skip notice posts and the check stays green.
+
+**Q4 — public repos only — "Who gets an automatic review?"** (`auto-review-authors`)
+- *Known contributors only (recommended)* → `"OWNER,MEMBER,COLLABORATOR,CONTRIBUTOR"`.
+- *Everyone* → `""`.
+
+Say plainly why Q4 exists: the workflow runs on `pull_request_target` with your
+OrcaRouter secret, so on a public repo a stranger's PR can spend from your wallet.
+Also tell them to set a budget + alert on the key at <https://www.orcarouter.ai/console/token>.
+
+Everything else keeps its default. Do not ask about `judge-model`, `concurrency`,
+`engine-version`, or `precision-filter` during install — see `references/inputs.md`
+if the user brings them up unprompted.
+
+### 3. Write the workflow
+
+Copy `assets/workflow.yml` to `.github/workflows/orca-code-review.yml`, then set the
+four values from step 2 under `with:`. Omit any input the user left at its default —
+a workflow that only lists what it overrides stays readable and lets the dashboard own
+the rest.
+
+Keep the `if:` condition and the `on:` block exactly as shipped. They encode two things
+that are easy to break: `pull_request_target` is what lets a fork PR be reviewed at all,
+and the author-association check on `issue_comment` is what stops any drive-by commenter
+from spending your quota with `/orcacode-review`.
+
+Show the user the final file before committing.
+
+### 4. Add the API key secret
+
+The secret must be named exactly `ORCAROUTER_API_KEY`.
+
+**Never ask the user to paste the key into the chat, and never read it from a file.**
+It would land in the transcript. Instead, tell them to run it themselves in this session:
+
+```
+! gh secret set ORCAROUTER_API_KEY --repo <owner/name>
+```
+
+`gh` prompts for the value and it never reaches you. Without `gh`, send them to
+`https://github.com/<owner>/<name>/settings/secrets/actions/new`.
+
+They can create or copy a key at <https://www.orcarouter.ai/console/token>.
+
+Then verify it exists without revealing it:
+
+```bash
+gh secret list --repo <owner/name> | grep ORCAROUTER_API_KEY
+```
+
+### 5. Enable the app
+
+Point the user at **OrcaRouter → Apps → OrcaCode Review** (<https://www.orcarouter.ai/>)
+to turn the app on and choose review models. Reviews will not run until it is enabled.
+
+### 6. Commit and open a test PR
+
+Commit on a branch, push, and open a PR — do not commit straight to the default branch.
+The PR is also the test: the workflow must run against a real pull request to prove out.
+
+```bash
+gh pr create --fill && gh run watch
+```
+
+### 7. Make the gate real
+
+A passing check blocks nothing until it is required. Walk the user through
+**Settings → Branches / Rulesets → Require status checks to pass** and adding the
+**`review`** check, or offer to do it:
+
+```bash
+gh api -X PATCH repos/<owner>/<name>/branches/<default>/protection/required_status_checks \
+  -f 'checks[][context]=review'
+```
+
+Confirm before running — branch protection changes affect everyone on the repo.
+
+### 8. Report
+
+Tell the user, concretely: the workflow path, the settings you chose, whether the
+secret and required check are in place, and the result of the test run. If any step
+was skipped (no `gh`, protection not applied), say which and what they still owe.
+
+## Reconfigure
+
+Read the existing `.github/workflows/orca-code-review.yml` first, then check whether
+`settings: "false"` is set.
+
+**If the dashboard owns settings (`settings` absent or `"true"`)** — most knobs are not
+in the file. Review mode, models, exhaustive mode, quiet mode, rubric, and the
+fix-first/block-on tuning all live at **OrcaRouter → Apps → OrcaCode Review**. Send the
+user there rather than editing YAML, and explain the precedence rule: an input written
+in the file only wins if it differs from its documented default.
+
+**If the file is authoritative (`settings: "false"`)** — edit it. Ask with
+`AskUserQuestion` which knobs to change, offering only what is relevant:
+
+- Merge policy (`block-on`) and fix-first escalation (`fix-first`).
+- Diff limits (`max-diff-kb`, `max-diff-files`) and `on-oversized-diff`.
+- Precision filter (`precision-filter`, `judge-model`, `judge-threshold`).
+- Run reporting (`report`) and token metering (`meter`).
+
+`references/inputs.md` has every input, its default, and what it actually controls.
+Read it before answering a question about behavior — do not guess a default.
+
+State the before → after for each value you change, and note that the new settings take
+effect on the next push to any open PR.
+
+## Troubleshoot
+
+Gather evidence before theorizing:
+
+```bash
+gh run list --workflow orca-code-review.yml --limit 5
+gh run view <run-id> --log-failed
+```
+
+`references/troubleshooting.md` maps each symptom to its cause and fix. The four that
+account for most reports:
+
+- **No run at all** — the PR is a draft and `trigger` is `ready_for_review`, the author
+  is outside `auto-review-authors`, or the app is off in the dashboard.
+- **Run fails immediately, auth error** — `ORCAROUTER_API_KEY` is missing, misnamed, or
+  scoped to an environment the job cannot read.
+- **"Diff too large" notice and a red check** — expected behavior with
+  `on-oversized-diff: "fail"`. Split the PR, or raise `max-diff-kb` / `max-diff-files`.
+- **Reviews work but the console's Settings/Analytics tabs are empty** — `@v1` points at
+  a commit older than `scripts/settings.mjs` / `scripts/report.mjs`. There is no error
+  for this; verify with `git ls-tree v1 scripts/` against the action repo.
+
+Report the actual failing output, not a paraphrase of it.
+
+## Uninstall
+
+Confirm with the user first, then in this order:
+
+1. **Drop the required check** — remove `review` from branch protection *before* deleting
+   the workflow. A required check whose workflow no longer exists never reports, and every
+   PR blocks forever with no way to clear it.
+2. **Delete the workflow** — `rm .github/workflows/orca-code-review.yml`, commit, push.
+3. **Leave the secret** — say that `ORCAROUTER_API_KEY` is harmless to keep and is worth
+   keeping if they may reinstall. Delete it only if they ask.
+4. **Mention the dashboard** — turning the app off at **OrcaRouter → Apps → OrcaCode
+   Review** stops any remaining billing.
+
+Do not delete old review comments. They are part of the PR history.

--- a/skills/setup-orca-code-review/assets/workflow.yml
+++ b/skills/setup-orca-code-review/assets/workflow.yml
@@ -1,0 +1,61 @@
+# OrcaCode Review — https://github.com/Continuum-AI-Corp/orca-code-review
+#
+# The review logic lives in the published action, so this file never copies
+# scripts or config — bump the version tag to update. Add one repository
+# secret, ORCAROUTER_API_KEY, and enable the app at
+# OrcaRouter -> Apps -> OrcaCode Review.
+
+name: OrcaCode Review
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  # `synchronize` re-reviews on every new push. `ready_for_review` makes the
+  # dashboard's trigger=ready_for_review mode fire when a draft becomes ready.
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write # tier state label + clean/fallback PR comments
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    # Run on PR events, or when a trusted user comments the review command on a
+    # PR. All four spellings are accepted — either prefix (`/` or `@`) with
+    # either separator (hyphen or space). The command runs this privileged
+    # `pull_request_target` workflow with the OrcaRouter secret, so only
+    # maintainers may trigger it — otherwise any participant could burn paid
+    # quota and spam reviews without pushing new commits.
+    if: |
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        (startsWith(github.event.comment.body, '/orcacode-review') ||
+          startsWith(github.event.comment.body, '/orcacode review') ||
+          startsWith(github.event.comment.body, '@orcacode-review') ||
+          startsWith(github.event.comment.body, '@orcacode review')) &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    steps:
+      - uses: Continuum-AI-Corp/orca-code-review@v1
+        with:
+          orcarouter-api-key: ${{ secrets.ORCAROUTER_API_KEY }}
+          # Everything below is optional. Keep only the lines you actually
+          # override — anything omitted follows the documented default (and,
+          # unless `settings: "false"`, the OrcaRouter dashboard).
+          #
+          # settings: "true"            # "false" = this file is authoritative
+          # block-on: "P0,P1"           # severities that fail the check
+          # fix-first: "P0,P1"          # withhold the strong tier until fixed
+          # on-oversized-diff: "fail"   # "pass" makes an oversized skip advisory
+          # auto-review-authors: ""     # public repos: e.g. "OWNER,MEMBER,COLLABORATOR,CONTRIBUTOR"
+          # max-diff-kb: "512"
+          # max-diff-files: "300"
+          # timeout-minutes: "20"
+          # report: "true"              # severity counts only — never code

--- a/skills/setup-orca-code-review/references/inputs.md
+++ b/skills/setup-orca-code-review/references/inputs.md
@@ -1,0 +1,105 @@
+# Action inputs
+
+Every input of `Continuum-AI-Corp/orca-code-review@v1`. Read the row before
+answering a question about behavior — do not guess a default.
+
+## Required
+
+| Input | Default | What it does |
+| --- | --- | --- |
+| `orcarouter-api-key` | — | OrcaRouter API key. Always pass it as `${{ secrets.ORCAROUTER_API_KEY }}`, never a literal. |
+
+## Routing and identity
+
+| Input | Default | What it does |
+| --- | --- | --- |
+| `orcarouter-url` | `https://api.orcarouter.ai/v1/chat/completions` | Chat-completions endpoint. Change only for a self-hosted gateway. |
+| `github-token` | `${{ github.token }}` | Fetches the PR head, posts comments, manages the tier label. |
+| `brand` | `OrcaCode Review` | Name shown on PR comments. |
+| `router` | `orcarouter/code-review` | Router alias that owns model selection. The action names no models: it injects raw facts (`x-cr-prev-tier`, `x-cr-prev-p0p1`) and this router's DSL recipe maps them to a concrete model. |
+| `engine-version` | `1.3.13` | Pinned `@alibaba-group/open-code-review` version. Bump deliberately — later steps parse its JSON output shape. |
+
+## Severity and merge gate
+
+| Input | Default | What it does |
+| --- | --- | --- |
+| `fix-first` | `P0,P1` | Severities that withhold the strong tier until fixed at the cheap tier. |
+| `block-on` | `P0,P1` | Severities that fail the check and block the merge. `""` means never block. |
+
+Values are `P0`, `P1`, `P2`, comma-separated, case-insensitive. An explicit
+empty string is valid and means "none".
+
+## Who gets reviewed
+
+| Input | Default | What it does |
+| --- | --- | --- |
+| `auto-review-authors` | `""` (everyone) | Author-association allowlist for **automatic** reviews. Others can still be reviewed on demand via `/orcacode-review`. Values: `OWNER`, `MEMBER`, `COLLABORATOR`, `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `FIRST_TIMER`, `MANNEQUIN`, `NONE`. |
+
+On a **public** repo this is a spend control, not a preference. The workflow runs on
+`pull_request_target`, which bypasses GitHub's fork-approval gate, and the key is
+wallet-metered — so any stranger opening a PR can trigger paid reviews. Set the
+allowlist and put a budget + alert on the key.
+
+## Oversized-diff guard
+
+| Input | Default | What it does |
+| --- | --- | --- |
+| `max-diff-kb` | `512` | Skip the review when the merge-base diff exceeds this size. |
+| `max-diff-files` | `300` | Skip when the diff touches more files than this. |
+| `on-oversized-diff` | `fail` | What a skip does to the check. `fail` means a diff padded past the limits cannot bypass a required gate. `pass` restores advisory behavior. |
+
+The guard runs **before** the engine, so an oversized PR costs nothing.
+
+## Precision filter
+
+Post-processing between the engine and the merge gate. Both layers are soft-fail:
+an error keeps the prior stage's findings and never aborts the review.
+
+| Input | Default | What it does |
+| --- | --- | --- |
+| `precision-filter` | `true` | L1 verifies each finding's `existing_code` snippet against the reviewed commit and re-homes or drops mismatches; L2 is an LLM judge that clusters by root cause and drops low-confidence findings. `false` posts the engine's raw findings. |
+| `judge-model` | `deepseek/deepseek-v4-pro` | Model for the L2 judge. Should differ from the reviewer model so it acts as an independent second opinion. Ignored when `precision-filter` is `false`. |
+| `judge-threshold` | `0.5` | Keep-threshold (0–1) for the judge's per-cluster confidence. Lower keeps more findings; raise to be stricter. |
+
+## Throughput
+
+| Input | Default | What it does |
+| --- | --- | --- |
+| `concurrency` | `24` | Max concurrent file reviews. Raise to shorten wall clock; lower it under a tight per-minute request quota. |
+| `max-tools` | `""` (engine default) | Max tool-call rounds per file. Lowering cuts cost and time but can cost review depth. |
+| `timeout-minutes` | `20` | Wall-clock ceiling for **one** engine pass. Exceeding it fails closed with a distinct "wall-clock timeout" error. Accepts decimals. Bump for very large diffs or slow models. |
+
+## Control plane
+
+| Input | Default | What it does |
+| --- | --- | --- |
+| `settings` | `true` | Fetch per-repo settings from the OrcaRouter dashboard at the start of each run. `false` skips the fetch and makes the workflow file authoritative. |
+| `report` | `true` | Send a per-run summary — repo, PR number, head SHA, tier, P0/P1/P2 counts, gate result, engine version. **Never code or finding text.** |
+| `meter` | `true` | Record per-call token accounting and print a totals table in the job log. Local only; nothing is uploaded. |
+
+### Precedence between the dashboard and this file
+
+With `settings: "true"` (the default), the dashboard supplies `auto_review`,
+`trigger`, `exhaustive`, `quiet`, `fix_first`, `block_on`, and `rubric`. A `with:`
+input wins **only when it differs from its documented default** — writing
+`block-on: "P0,P1"` explicitly changes nothing, because that *is* the default.
+
+To make the file unambiguously authoritative, set `settings: "false"`. The fetch is
+skipped entirely and no server value can apply.
+
+The settings fetch fails **open**: a control-plane outage falls back to built-in
+defaults rather than killing the review.
+
+## Dashboard-only settings
+
+These have no workflow input. They live at **OrcaRouter → Apps → OrcaCode Review**
+and only apply when `settings` is `true`.
+
+| Setting | Values | What it does |
+| --- | --- | --- |
+| `auto_review` | on / off | Master switch for automatic reviews. |
+| `trigger` | `every_push`, `ready_for_review`, `on_demand` | When an automatic review fires. `ready_for_review` skips drafts. |
+| `exhaustive` | on / off | Extra engine passes on the strong tier, deduped. Costs more. |
+| `quiet` | on / off | Mutes P2 at posting time. The gate and the run report still see true counts. |
+| `rubric` | free text | Server-side rubric override for the review prompt. |
+| Models | per tier | Which model runs each tier. The action never names a model. |

--- a/skills/setup-orca-code-review/references/troubleshooting.md
+++ b/skills/setup-orca-code-review/references/troubleshooting.md
@@ -1,0 +1,99 @@
+# Troubleshooting
+
+Collect evidence first. A guess costs more than a command.
+
+```bash
+gh run list --workflow orca-code-review.yml --limit 5
+gh run view <run-id> --log-failed
+gh secret list | grep ORCAROUTER_API_KEY
+```
+
+## No workflow run appears at all
+
+The job never started, so there are no logs. Work down this list:
+
+| Check | How | Fix |
+| --- | --- | --- |
+| Workflow exists **on the base branch** | `git show origin/<default>:.github/workflows/orca-code-review.yml` | `pull_request_target` reads the workflow from the base branch, not the PR head. A workflow added only in the PR branch will not run until it merges. |
+| App is enabled | OrcaRouter → Apps → OrcaCode Review | Turn it on. |
+| `auto_review` is on | Dashboard | Off means no automatic reviews. `/orcacode-review` still works. |
+| PR is not a draft | `gh pr view --json isDraft` | With `trigger: ready_for_review`, drafts are skipped by design. Mark it ready. |
+| Author is allowed | `gh pr view --json authorAssociation` | If it is outside `auto-review-authors`, a maintainer can run `/orcacode-review`. |
+| Actions are enabled | Repo Settings → Actions | Forked repos ship with Actions disabled. |
+
+## `/orcacode-review` does nothing
+
+The comment gate requires **both**: the comment starts with one of
+`/orcacode-review`, `/orcacode review`, `@orcacode-review`, `@orcacode review`
+(a leading space or quote breaks `startsWith`), **and** the commenter's
+`author_association` is `OWNER`, `MEMBER`, or `COLLABORATOR`.
+
+An outside contributor commenting the command is silently ignored. That is
+deliberate — the command runs a privileged workflow holding the paid key.
+
+## Run fails immediately with an auth error
+
+| Cause | Tell |
+| --- | --- |
+| Secret missing or misnamed | `gh secret list` shows no `ORCAROUTER_API_KEY`. The name is exact and case-sensitive. |
+| Secret set on an environment or another repo | Repository secrets and environment secrets are different scopes. The job reads repository (or org) secrets. |
+| Key revoked or out of budget | Check <https://www.orcarouter.ai/console/token>. A wallet at its limit returns an auth-shaped failure. |
+| Fork PR | Secrets are unavailable to `pull_request` from forks — which is exactly why the shipped workflow uses `pull_request_target`. If someone replaced the trigger, that is the bug. |
+
+## "Diff too large" notice, check is red
+
+Working as configured. The guard runs before the engine, so nothing was spent.
+
+- Split the PR — the real fix, and it reviews better.
+- Or raise `max-diff-kb` / `max-diff-files`.
+- Or set `on-oversized-diff: "pass"` to make the skip advisory. Understand the
+  trade first: with a required check, `pass` means a big enough PR can walk
+  straight through the gate unreviewed.
+
+## Review runs, but no comments appear
+
+| Cause | Fix |
+| --- | --- |
+| Nothing was found | A clean run posts a summary, not inline comments. Check the job log's severity counts. |
+| Quiet mode | P2 findings are muted at posting time. The gate and report still counted them — the log will show a nonzero P2. |
+| Precision filter dropped them | L1 drops findings whose `existing_code` snippet does not match the reviewed commit; L2 drops low-confidence clusters. Lower `judge-threshold`, or set `precision-filter: "false"` to see raw output. |
+| Missing permissions | The job needs `pull-requests: write` and `issues: write`. |
+
+## Reviews work, but the console's Settings and Analytics tabs are empty
+
+`@v1` points at a commit that predates `scripts/settings.mjs` and
+`scripts/report.mjs`. Settings are never fetched and runs are never reported —
+**with no error message**. Two dead tabs and working reviews is the signature.
+
+Verify against the action repo:
+
+```bash
+git ls-tree v1 scripts/ | grep -E 'settings|report'
+```
+
+Fix by pinning a newer tag or an immutable commit SHA instead of `@v1`.
+
+## Findings look wrong or noisy
+
+- Tighten the rubric at **OrcaRouter → Apps → OrcaCode Review**.
+- Raise `judge-threshold` above `0.5` to drop more low-confidence findings.
+- Set `judge-model` to something other than the reviewer model — a judge that is
+  the same model is not an independent second opinion.
+- Turn on quiet mode to keep P2 out of the PR while still counting it.
+
+## Merges are not actually blocked
+
+A red check blocks nothing until it is required. Add **`review`** under
+**Settings → Branches / Rulesets → Require status checks to pass**.
+
+Also confirm `block-on` is not `""`, and that the reviewed severities are the ones
+you expect — with the dashboard authoritative, `block_on` may have been changed in
+the console rather than in the file.
+
+## The run times out
+
+`timeout-minutes` (default 20) is a ceiling on **one** engine pass. Exceeding it
+fails closed with a distinct "wall-clock timeout" error, separate from
+"no usable result" — the log says which. Raise it for very large diffs or
+slow-per-call models, or lower `concurrency` if the model is rate-limiting and the
+retries are what is eating the clock.


### PR DESCRIPTION
Two ways to install OrcaCode Review without hand-writing YAML, plus the agent skill that drives them conversationally.

## What ships

**`npx orcacode-review`** — zero-dependency CLI, full lifecycle:

```
init | reconfigure | doctor | uninstall | skill install | skill list
```

**`.claude-plugin/`** — this repo becomes its own plugin marketplace:

```
/plugin marketplace add Continuum-AI-Corp/orca-code-review
/plugin install orca-code-review
```

**`skills/setup-orca-code-review/`** — English skill covering install, reconfigure, troubleshoot, uninstall. Installs into **36 agent platforms** (Claude Code, Codex, Cursor, OpenCode, Copilot, …).

## Decisions worth reviewing

- **The API key never passes through this process.** `gh secret set` runs with inherited stdio so the user types it into `gh`, not into argv (visible in `ps`) or an agent transcript. Under `--yes`/non-TTY the CLI skips it and prints the URL.
- **Only non-default inputs get written.** With the dashboard authoritative, an input equal to its default changes nothing — writing it implies control the file does not have.
- **`uninstall` drops the required check first.** A required check whose workflow is gone never reports, and every PR blocks forever with no way to clear it.
- **`doctor` checks the BASE branch,** not just the working tree. `pull_request_target` reads the workflow from there, so a feature-branch-only file produces no runs and no error.
- **Platform catalog is a port of `orcadub-mcp-server`'s** — IDs and paths included, so `--platform codex` means the same directory in both products. Two detection rules are load-bearing and now tested: never detect on a root most repos have (`.github`, `.`), never detect on an executable that collides with a stock system binary (Command Code's `cmd`).
- **Skill installs compare the whole tree.** A half-updated skill — new SKILL.md pointing at a prior version's reference file — is worse than either version alone, because the agent follows the link and cannot tell. An existing differing copy is never overwritten without `--force`.
- **zh/en throughout,** from the locale or `--lang`. Prose only: flags, platform IDs, workflow inputs, and shell commands stay verbatim in both, because the reader still has to type them.

## Release order

`RELEASE.md` gains an **Installers** section. Both installers generate `@v1`, so they must not ship ahead of the tag. Verified before this PR:

```
$ git ls-tree v1 scripts/ | grep -E 'settings|report'
scripts/report.mjs  scripts/settings.mjs   ✓
```

Three versions move together on a feature release: `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`.

## Tests

54 new (334 total), all passing on the existing `node --test scripts/*.test.mjs` run — no CI change needed.

- `installer.test.mjs` — workflow render/parse round trip, incl. `block-on: ""` surviving as an explicit "none" rather than being dropped as falsy
- `platforms.test.mjs` — catalog invariants, the two detection rules, path dedup (Codex/Antigravity/Antigravity 2.0 collapse to one `.agents` target in project scope but stay separate globally), tree install statuses
- `i18n.test.mjs` — the two string tables cannot diverge: missing key, extra key, or differing argument count (which would silently drop a branch name from Chinese output)