### PR TITLE
fix: run the CLI when npm invokes it through its bin symlink

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Skills for OrcaRouter products.",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "plugins": [
     {
@@ -14,7 +14,12 @@
       "source": "./",
       "description": "Set up, reconfigure, troubleshoot, and remove OrcaCode Review — AI pull-request review powered by OrcaRouter — in any GitHub repository.",
       "category": "code-review",
-      "keywords": ["code-review", "github-actions", "ci", "pull-request"]
+      "keywords": [
+        "code-review",
+        "github-actions",
+        "ci",
+        "pull-request"
+      ]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orca-code-review",
   "description": "Set up, reconfigure, troubleshoot, and remove OrcaCode Review — AI pull-request review powered by OrcaRouter — in any GitHub repository.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Continuum-AI-Corp",
     "url": "https://github.com/Continuum-AI-Corp"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,6 +137,40 @@ jobs:
             console.log("tarball ok — " + files.length + " files");
           '
 
+      # Install the real tarball and run it through npm's real `.bin` shim.
+      #
+      # This exists because 1.0.0 shipped a CLI that did nothing. npm installs a
+      # `bin` as a symlink, so argv[1] is the link while import.meta.url is its
+      # target; the entry-point guard compared them without realpath and was
+      # false for every npx and every global install. The process exited 0
+      # having printed nothing, and every check above passed. `node bin/...`
+      # never takes that path, so only an actual install can catch its kind.
+      - name: Smoke-test the packed tarball
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          set -euo pipefail
+          TARBALL="$PWD/$(npm pack --json | node -pe 'JSON.parse(require("fs").readFileSync(0,"utf8"))[0].filename')"
+          SMOKE=$(mktemp -d)
+          cd "$SMOKE"
+          npm init -y >/dev/null 2>&1
+          npm install --no-audit --no-fund --silent "$TARBALL"
+
+          SHIM=./node_modules/.bin/orcacode-review
+          test -L "$SHIM" || echo "::warning::$SHIM is not a symlink — this platform cannot exercise that path"
+
+          PRINTED=$("$SHIM" --version)
+          echo "shim printed: '$PRINTED'"
+          if [ "$PRINTED" != "${{ steps.check.outputs.version }}" ]; then
+            echo "::error::the installed bin printed '$PRINTED', expected '${{ steps.check.outputs.version }}'." \
+                 "An empty value means the entry-point guard rejected npm's symlink."
+            exit 1
+          fi
+
+          # A real subcommand, so the check covers more than argument parsing.
+          "$SHIM" skill list --lang en | grep -q "claude" || {
+            echo "::error::\`skill list\` did not list the platform catalog"; exit 1; }
+          echo "tarball smoke test passed"
+
       - name: Publish
         if: steps.check.outputs.needed == 'true'
         run: npm publish --access public --provenance

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -64,7 +64,7 @@ revert each make "the previous commit" the wrong thing to compare against, and
 that failure is silent in both directions — a missed release, or a publish that
 dies on E409.
 
-Four gates run before the point of no return, and each one fails the job:
+Five gates run before the point of no return, and each one fails the job:
 
 1. `package.json`, `.claude-plugin/plugin.json`, and
    `.claude-plugin/marketplace.json` all carry the same version.
@@ -73,6 +73,17 @@ Four gates run before the point of no return, and each one fails the job:
 3. The full test suite passes.
 4. The tarball actually contains `bin/` and the skill — a tarball missing them
    publishes cleanly and only fails on the user's first `npx`.
+5. The packed tarball is installed into a scratch project and run through npm's
+   own `node_modules/.bin` shim, asserting it prints the expected version and
+   that `skill list` produces the catalog.
+
+Gate 5 exists because 1.0.0 shipped a CLI that did nothing. npm installs a `bin`
+as a **symlink**, so `argv[1]` is the link while `import.meta.url` is its
+target; the entry-point guard compared the two without `realpath` and was false
+for every `npx` and every global install. The process exited 0 having printed
+nothing, and gates 1–4 all passed. Running `node bin/orcacode-review.mjs` never
+takes that path, so nothing short of a real install can catch that class of bug.
+`scripts/installer.test.mjs` now also execs the CLI through a symlink.
 
 npm's unpublish window is 72 hours and a withdrawn version number can never be
 reused, so anything checkable before publishing is checked there rather than

--- a/bin/orcacode-review.mjs
+++ b/bin/orcacode-review.mjs
@@ -24,7 +24,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline/promises";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 
 import { SKILL_PLATFORMS, POPULAR_PLATFORM_IDS, findPlatform, detectPlatforms, resolveTargets } from "./platforms.mjs";
@@ -904,10 +904,25 @@ async function main() {
 
 // Only run when invoked as a program. Importing this file (the test suite does)
 // must not touch the filesystem or open a readline interface.
-const invokedDirectly =
-  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+//
+// Both sides are resolved through realpath before comparing. npm installs a
+// `bin` as a SYMLINK at node_modules/.bin/<name>, so argv[1] is the link while
+// import.meta.url is the link's target — comparing them raw is false for every
+// npx and every global install, and the CLI exits 0 having done nothing at all.
+// That failure is invisible when testing with `node bin/orcacode-review.mjs`,
+// which is why installer.test.mjs now execs through a symlink.
+function invokedDirectly() {
+  if (!process.argv[1]) return false;
+  try {
+    return fs.realpathSync(process.argv[1]) === fs.realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    // A path that cannot be resolved (deleted, permission-denied) is not a
+    // direct invocation we can prove — stay quiet rather than run by accident.
+    return false;
+  }
+}
 
-if (invokedDirectly) {
+if (invokedDirectly()) {
   main()
     .catch((e) => die(e?.message || String(e)))
     .finally(closeUi);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orcacode-review",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "One-command installer for OrcaCode Review — AI pull-request review powered by OrcaRouter.",
   "bin": {
     "orcacode-review": "bin/orcacode-review.mjs"

--- a/scripts/installer.test.mjs
+++ b/scripts/installer.test.mjs
@@ -8,12 +8,65 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 import {
   DEFAULTS,
   renderWorkflow,
   parseOverrides,
 } from "../bin/orcacode-review.mjs";
+
+const CLI = fileURLToPath(new URL("../bin/orcacode-review.mjs", import.meta.url));
+
+// --------------------------------------------------------------- entry point ---
+
+test("the CLI runs when executed through a symlink", () => {
+  // npm installs a `bin` as a SYMLINK at node_modules/.bin/<name>, so argv[1]
+  // is the link and import.meta.url is its target. An entry-point guard that
+  // compares them without realpath is false for every npx and every global
+  // install: the process exits 0 having printed nothing. Shipped as 1.0.0 and
+  // only caught by installing the published tarball, because running
+  // `node bin/orcacode-review.mjs` directly never takes that path.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ocr-bin-"));
+  const link = path.join(dir, "orcacode-review");
+  try {
+    fs.symlinkSync(CLI, link);
+  } catch (e) {
+    if (e.code === "EPERM" || e.code === "ENOSYS") return; // unprivileged Windows
+    throw e;
+  }
+
+  const r = spawnSync(process.execPath, [link, "--version"], { encoding: "utf8" });
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout.trim(), /^\d+\.\d+\.\d+$/, "no version printed — the guard rejected the symlink");
+});
+
+test("the CLI runs when executed by its real path", () => {
+  const r = spawnSync(process.execPath, [CLI, "--version"], { encoding: "utf8" });
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout.trim(), /^\d+\.\d+\.\d+$/);
+});
+
+test("importing the CLI runs nothing", () => {
+  // The guard's other half: a bare import must not start the interactive flow.
+  const r = spawnSync(
+    process.execPath,
+    ["--input-type=module", "-e", `import(${JSON.stringify(CLI)}).then(m => console.log(Object.keys(m).sort().join(",")))`],
+    { encoding: "utf8" },
+  );
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(r.stdout.trim(), "DEFAULTS,parseOverrides,readOverrides,renderWorkflow");
+});
+
+test("the published version matches package.json", () => {
+  const pkg = JSON.parse(fs.readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+  const r = spawnSync(process.execPath, [CLI, "--version"], { encoding: "utf8" });
+  assert.equal(r.stdout.trim(), pkg.version);
+});
 
 const withBlock = (yaml) =>
   yaml.slice(yaml.indexOf("        with:")).split("\n").slice(1).filter((l) => l.trim());


### PR DESCRIPTION
**`orcacode-review@1.0.0` is inert.** `npx orcacode-review` and any global install exit 0 having printed nothing.

## Cause

npm installs a `bin` as a **symlink**:

```
node_modules/.bin/orcacode-review -> ../orcacode-review/bin/orcacode-review.mjs
```

So `argv[1]` is the link and `import.meta.url` is its target. The entry-point guard compared them raw:

```js
process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href   // false for every install
```

`main()` never ran. Resolving both sides through `realpath` fixes it.

## Why nothing caught it

Every local invocation was `node bin/orcacode-review.mjs` — the one path where `argv[1]` and `import.meta.url` already agree. The publish workflow's four gates all passed: versions in sync, `v1` tag valid, 334 tests green, tarball contains `bin/` and the skill. A tarball can be perfectly well-formed and still not execute.

## Two gaps closed

**`installer.test.mjs`** now execs the CLI three ways — through a symlink, by real path, and via `import` (asserting the import runs nothing and exports exactly the four expected names). Confirmed the symlink test fails against the old guard and passes against the new one.

**`publish.yml`** gains a fifth gate before the point of no return: pack the tarball, install it into a scratch project, run it through npm's own `.bin` shim, and assert both the printed version and that `skill list` produces the catalog. Run locally against this branch:

```
is symlink: yes
version:    '1.0.1'
```

## Version

1.0.1 across `package.json`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`, as the sync gate requires. Merging publishes it.

1.0.0 stays on the registry — unpublishing burns the version number permanently and 1.0.1 supersedes it for anyone using `@latest`.