### PR TITLE
feat!: publish under the orcarouter org as @orcarouter/code-review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Skills for OrcaRouter products.",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orca-code-review",
   "description": "Set up, reconfigure, troubleshoot, and remove OrcaCode Review — AI pull-request review powered by OrcaRouter — in any GitHub repository.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "Continuum-AI-Corp",
     "url": "https://github.com/Continuum-AI-Corp"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-# Publish `orcacode-review` to npm when its version is not on the registry yet.
+# Publish `@orcarouter/code-review` to npm when its version is not on the registry yet.
 #
 # The trigger is every push to main, but the decision is "is this exact version
 # already published?" — not "did package.json change in this commit?". Diffing

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Either installer writes the workflow, guides you through the API key, and sets u
 **Terminal — no install required:**
 
 ```bash
-npx orcacode-review
+npx @orcarouter/code-review
 ```
 
 **Claude Code — as a plugin:**
@@ -55,10 +55,10 @@ Then ask: *"set up OrcaCode Review in this repo"*. The skill also handles reconf
 The CLI has the same lifecycle commands:
 
 ```bash
-npx orcacode-review init          # write the workflow
-npx orcacode-review reconfigure   # change blocking rules, diff limits, where config lives
-npx orcacode-review doctor        # diagnose reviews that don't run or don't post
-npx orcacode-review uninstall     # remove it (drops the merge gate first)
+npx @orcarouter/code-review init          # write the workflow
+npx @orcarouter/code-review reconfigure   # change blocking rules, diff limits, where config lives
+npx @orcarouter/code-review doctor        # diagnose reviews that don't run or don't post
+npx @orcarouter/code-review uninstall     # remove it (drops the merge gate first)
 ```
 
 Prefer to wire it by hand? The manual steps are below.
@@ -68,15 +68,15 @@ Prefer to wire it by hand? The manual steps are below.
 The setup skill installs into **36 agent platforms** — the same catalog the [OrcaDub MCP server](https://github.com/Continuum-AI-Corp/orcadub-mcp-server) uses, so IDs and paths match across Orca products.
 
 ```bash
-npx orcacode-review skill list      # all 36, with the ones detected here marked
-npx orcacode-review skill install   # pick from a checkbox list; detected agents pre-checked
+npx @orcarouter/code-review skill list      # all 36, with the ones detected here marked
+npx @orcarouter/code-review skill install   # pick from a checkbox list; detected agents pre-checked
 ```
 
 Detected platforms are pre-selected. For unattended or agent-driven setup, name them:
 
 ```bash
-npx orcacode-review skill install --platform claude --platform codex --scope project --yes
-npx orcacode-review skill install --platform cursor --scope global --yes
+npx @orcarouter/code-review skill install --platform claude --platform codex --scope project --yes
+npx @orcarouter/code-review skill install --platform cursor --scope global --yes
 ```
 
 Claude Code, Cursor, Codex, OpenCode, Windsurf, Cline, RooCode, Continue, GitHub Copilot, Gemini CLI, Amazon Q Developer, Qwen Code, Kilo Code, Auggie, Kimi Code, Kiro, Lingma, Junie, CodeBuddy Code, CoStrict, Crush, Factory Droid, iFlow, Pi, Qoder, Antigravity, Antigravity 2.0, Bob Shell, ForgeCode, Trae, Trae CN, ZCode, MimoCode, Hermes, OpenClaw, Command Code.
@@ -88,8 +88,8 @@ An existing identical skill is left unchanged; an existing **different** one is 
 The CLI speaks **English and Simplified Chinese**, picked from your locale (`LC_ALL` / `LC_MESSAGES` / `LANG`). Override it per run, or pin it for good:
 
 ```bash
-npx orcacode-review --lang zh          # 中文界面
-npx orcacode-review --lang en          # English
+npx @orcarouter/code-review --lang zh          # 中文界面
+npx @orcarouter/code-review --lang en          # English
 export ORCACODE_LANG=zh                # 固定下来
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -47,10 +47,37 @@ that pins `@v1`. **Release them only after the `v1` tag has been moved** — an
 installer that writes `@v1` against a stale tag hands every new user the dead
 Settings/Analytics tabs described above, on their very first run.
 
-### npm — `npx orcacode-review`
+### npm — `npx @orcarouter/code-review`
 
-Package name is `orcacode-review` (one word, matching the product name and the
-`/orcacode-review` PR command); the repo and action stay `orca-code-review`.
+Package name is **`@orcarouter/code-review`**, under the `orcarouter`
+organization scope. The **bin** it installs is still `orcacode-review` (one
+word, matching the product name and the `/orcacode-review` PR command), so a
+global install gives a short command while the package name carries the org:
+
+```
+npx @orcarouter/code-review          # the package name
+orcacode-review --version            # the command, after `npm i -g`
+```
+
+The repo and the action stay `orca-code-review`.
+
+`publishConfig.access` is `public` in `package.json`. Scoped packages default to
+**restricted**, so without it a hand-run `npm publish` that forgets
+`--access public` ships it private and the documented install command 404s for
+everyone outside the org.
+
+#### The unscoped `orcacode-review` name is retired
+
+1.0.0 and 1.0.1 were published unscoped under a personal account, before the
+move to the org. Neither is maintained, and 1.0.0 additionally does not run at
+all (see gate 5). Leave both on the registry — unpublishing burns those version
+numbers permanently — but mark the name dead:
+
+```
+npm deprecate orcacode-review "Moved to @orcarouter/code-review"
+```
+
+Never publish to the old name again.
 
 **Publishing is automatic.** To cut a release, bump `version` in `package.json`
 (and the two `.claude-plugin` files — see below) and merge to `main`. That is
@@ -102,7 +129,7 @@ manual, per the section above.
 Smoke-test after a release:
 
 ```
-npx orcacode-review@latest skill list
+npx @orcarouter/code-review@latest skill list
 ```
 
 `files` in `package.json` ships only `bin/` and `skills/` — the action itself is

--- a/bin/i18n.mjs
+++ b/bin/i18n.mjs
@@ -118,13 +118,13 @@ const EN = {
       "     only starts once this file is on your default branch.",
     step3: "  3. Make the gate real: Settings → Branches / Rulesets → Require status checks",
     step3Note: (check) => `     and add the ${check} check. A red check blocks nothing until it is required.`,
-    diagnoseHint: "  Diagnose anytime with: npx orcacode-review doctor",
+    diagnoseHint: "  Diagnose anytime with: npx @orcarouter/code-review doctor",
   },
 
   reconfigure: {
     title: "OrcaCode Review — reconfigure",
     missing: (p) => `No workflow at ${p}.`,
-    missingHint: "Run `npx orcacode-review init` first.",
+    missingHint: "Run `npx @orcarouter/code-review init` first.",
     dashboardOwns: "This install lets the OrcaRouter dashboard own most settings.",
     dashboardOwnsDetail: (url) =>
       "  Review mode, models, exhaustive mode, quiet mode, and the rubric are not in\n" +
@@ -143,7 +143,7 @@ const EN = {
     repoUnknown: "(unknown)",
     workflowExists: (p) => `${p} exists`,
     workflowMissing: (p) => `${p} is missing`,
-    workflowMissingFix: "Run: npx orcacode-review init",
+    workflowMissingFix: "Run: npx @orcarouter/code-review init",
     onBase: (b) => `Present on origin/${b}`,
     notOnBase: (b) => `Not on origin/${b} yet`,
     notOnBaseFix:
@@ -188,7 +188,7 @@ const EN = {
 
   skill: {
     missingBundle: "The bundled skill is missing from this package.",
-    missingBundleHint: "Reinstall with: npx orcacode-review@latest skill",
+    missingBundleHint: "Reinstall with: npx @orcarouter/code-review@latest skill",
     scopeQ: "Where should the skill be installed?",
     scopeProject: "This project",
     scopeProjectDetail: "Committed with the repo — everyone who clones it gets the skill.",
@@ -197,7 +197,7 @@ const EN = {
     unknownScope: (s) => `Unknown scope "${s}".`,
     unknownScopeHint: "Use --scope project or --scope global.",
     unknownPlatform: (id) => `Unknown platform "${id}".`,
-    unknownPlatformHint: "List them with: orcacode-review skill list",
+    unknownPlatformHint: "List them with: npx @orcarouter/code-review skill list",
     noneDetected: "No agent platform detected here, and none was named.",
     noneDetectedHint:
       "Pass one explicitly, e.g. --platform claude --platform codex (`skill list` shows all 36).",
@@ -211,7 +211,7 @@ const EN = {
     pluginHint: "  For Claude Code, the plugin keeps itself updated instead:",
     listTitle: (n) => `${n} supported platforms`,
     listColumns: "  (project root / global root)",
-    listLegend: "  ● = detected here.  Install with: orcacode-review skill install --platform <id>",
+    listLegend: "  ● = detected here.  Install with: npx @orcarouter/code-review skill install --platform <id>",
   },
 
   secret: {
@@ -337,13 +337,13 @@ const ZH = {
       "     默认分支，评审才会开始跑。",
     step3: "  3. 让门禁真正生效：Settings → Branches / Rulesets → Require status checks",
     step3Note: (check) => `     把 ${check} 检查设为必需。检查变红本身拦不住任何东西。`,
-    diagnoseHint: "  随时体检：npx orcacode-review doctor",
+    diagnoseHint: "  随时体检：npx @orcarouter/code-review doctor",
   },
 
   reconfigure: {
     title: "OrcaCode Review —— 修改配置",
     missing: (p) => `找不到 ${p}。`,
-    missingHint: "先运行 `npx orcacode-review init`。",
+    missingHint: "先运行 `npx @orcarouter/code-review init`。",
     dashboardOwns: "这个安装把大部分配置交给了 OrcaRouter 控制台。",
     dashboardOwnsDetail: (url) =>
       "  评审模式、模型、穷尽模式、静默模式和评分规则都不在这个文件里 ——\n" +
@@ -362,7 +362,7 @@ const ZH = {
     repoUnknown: "（未知）",
     workflowExists: (p) => `${p} 存在`,
     workflowMissing: (p) => `缺少 ${p}`,
-    workflowMissingFix: "运行：npx orcacode-review init",
+    workflowMissingFix: "运行：npx @orcarouter/code-review init",
     onBase: (b) => `已在 origin/${b} 上`,
     notOnBase: (b) => `还没进 origin/${b}`,
     notOnBaseFix: "pull_request_target 从「目标分支」读取 workflow。合并进去之后才会有运行记录。",
@@ -404,7 +404,7 @@ const ZH = {
 
   skill: {
     missingBundle: "这个包里缺少内置的 skill。",
-    missingBundleHint: "重新安装：npx orcacode-review@latest skill",
+    missingBundleHint: "重新安装：npx @orcarouter/code-review@latest skill",
     scopeQ: "skill 装到哪里？",
     scopeProject: "当前项目",
     scopeProjectDetail: "随仓库提交 —— 每个 clone 的人都能用。",
@@ -413,7 +413,7 @@ const ZH = {
     unknownScope: (s) => `未知的安装范围「${s}」。`,
     unknownScopeHint: "用 --scope project 或 --scope global。",
     unknownPlatform: (id) => `未知平台「${id}」。`,
-    unknownPlatformHint: "用 orcacode-review skill list 查看全部。",
+    unknownPlatformHint: "用 npx @orcarouter/code-review skill list 查看全部。",
     noneDetected: "这里没检测到任何 Agent 平台，也没有指定平台。",
     noneDetectedHint: "请显式指定，例如 --platform claude --platform codex（`skill list` 列出全部 36 个）。",
     platformQ: "要把 skill 装到哪些 Agent？",
@@ -426,7 +426,7 @@ const ZH = {
     pluginHint: "  Claude Code 建议改用插件，它会自动保持更新：",
     listTitle: (n) => `支持 ${n} 个平台`,
     listColumns: "  （项目路径 / 全局路径）",
-    listLegend: "  ● = 本机已检测到。安装：orcacode-review skill install --platform <id>",
+    listLegend: "  ● = 本机已检测到。安装：npx @orcarouter/code-review skill install --platform <id>",
   },
 
   secret: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "orcacode-review",
-  "version": "1.0.1",
+  "name": "@orcarouter/code-review",
+  "version": "1.0.2",
   "description": "One-command installer for OrcaCode Review — AI pull-request review powered by OrcaRouter.",
   "bin": {
     "orcacode-review": "bin/orcacode-review.mjs"
@@ -35,5 +35,8 @@
     "url": "https://github.com/Continuum-AI-Corp/orca-code-review/issues"
   },
   "author": "Continuum-AI-Corp",
-  "license": "MIT"
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/scripts/i18n.test.mjs
+++ b/scripts/i18n.test.mjs
@@ -88,7 +88,7 @@ test("commands and flags survive translation", () => {
     "--force", "--platform", "--scope", "--yes", "--help", "--lang",
     "gh secret set", "gh auth login", "gh run view",
     "pull_request_target", "auto_review", "ready_for_review", "auto-review-authors",
-    "npx orcacode-review", "orcacode-review skill list", "/orcacode-review",
+    "npx @orcarouter/code-review", "@orcarouter/code-review skill list", "/orcacode-review",
   ];
   const present = candidates.filter((literal) => en.includes(literal));
   assert.ok(present.length >= 10, "the English table stopped mentioning the literals this test guards");

--- a/scripts/installer.test.mjs
+++ b/scripts/installer.test.mjs
@@ -1,4 +1,4 @@
-// Tests for the `npx orcacode-review` workflow renderer.
+// Tests for the `npx @orcarouter/code-review` workflow renderer.
 //
 // The renderer decides what a consumer's CI actually does, so the two
 // properties worth pinning are: (1) it only writes inputs that differ from
@@ -148,4 +148,43 @@ test("commented-out example inputs are not read as overrides", () => {
 test("a trailing comment on a real input does not leak into the value", () => {
   const text = '          block-on: "P0"  # severities that fail the check\n';
   assert.equal(parseOverrides(text)["block-on"], "P0");
+});
+
+// ------------------------------------------------------------ package identity ---
+
+const PKG = JSON.parse(fs.readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+
+test("a scoped package declares public access", () => {
+  // Scoped packages default to RESTRICTED. Without publishConfig, a hand-run
+  // publish that forgets `--access public` ships it private, and the install
+  // command in the README 404s for everyone outside the org.
+  if (!PKG.name.startsWith("@")) return;
+  assert.equal(PKG.publishConfig?.access, "public");
+});
+
+test("the installed command is short even though the package name is scoped", () => {
+  // `npm i -g` creates a command named by the bin KEY, not the package name.
+  assert.deepEqual(Object.keys(PKG.bin), ["orcacode-review"]);
+});
+
+test("every npx invocation in the strings names the real package", () => {
+  // The failure this catches: renaming the package and leaving `npx <old-name>`
+  // in a hint, so the tool confidently tells people to run something that does
+  // not exist. Moving to the org scope touched thirteen such strings across
+  // two languages, and nothing but a grep would have caught a miss.
+  const i18n = fs.readFileSync(new URL("../bin/i18n.mjs", import.meta.url), "utf8");
+  const named = [...i18n.matchAll(/npx ([@\w./-]+)/g)].map((m) => m[1].replace(/@latest$/, ""));
+  assert.ok(named.length > 0, "no npx invocations found — did the hints move?");
+  for (const name of new Set(named)) {
+    assert.equal(name, PKG.name, `stale package name in a hint: npx ${name}`);
+  }
+});
+
+test("every npx invocation in the README names the real package", () => {
+  const readme = fs.readFileSync(new URL("../README.md", import.meta.url), "utf8");
+  const named = [...readme.matchAll(/npx ([@\w./-]+)/g)].map((m) => m[1].replace(/@latest$/, ""));
+  assert.ok(named.length > 0);
+  for (const name of new Set(named)) {
+    assert.equal(name, PKG.name, `stale package name in README: npx ${name}`);
+  }
 });


### PR DESCRIPTION
**BREAKING — the install command changes:**

```
npx orcacode-review          →   npx @orcarouter/code-review
```

## Why now

The package went out unscoped under a personal account (`kaifeng.an`). Moving it under the org puts it where the product lives — and **now is the only cheap moment**: a scoped package cannot be re-scoped later, so this option exists only while the name is still unscoped.

## The bin stays short

`npm i -g` names the installed command after the **bin key**, not the package name. So:

```
npx @orcarouter/code-review     # package name — carries the org
orcacode-review --version       # command after a global install
```

Verified against a real install of the packed tarball: bin is a symlink, prints `1.0.2`, `--lang zh` renders.

## `publishConfig.access: public`

Scoped packages default to **restricted**. Without this, a hand-run publish that forgets `--access public` ships it private and the README's install command 404s for everyone outside the org. The workflow already passes the flag; this is the belt to its braces.

## The old name

1.0.0 and 1.0.1 stay on the registry — unpublishing burns those version numbers permanently. `RELEASE.md` records the deprecation that points the dead name here:

```
npm deprecate orcacode-review "Moved to @orcarouter/code-review"
```

(1.0.0 was the inert build fixed in #20; 1.0.1 works but is unmaintained.)

## Four new tests

A rename is precisely the change that strews stale strings behind it — this one touched **thirteen** invocation hints across two languages. Grep found them; nothing would have caught a miss. Now something does:

- `publishConfig.access` is public whenever the name is scoped
- the bin key is still the short command
- every `npx …` in `bin/i18n.mjs` names the real package
- every `npx …` in `README.md` names the real package

342 tests passing.

## Before merging

The current `NPM_TOKEN` cannot publish this — it is scoped to the old package name and/or lacks org rights. **Regenerate it** with access to the `orcarouter` org, then `gh secret set NPM_TOKEN`. The Organizations section on the token page will now have `orcarouter` selectable, which it did not before.

If the token is wrong the job fails at the last step, after all five gates pass — noisy but harmless, and nothing gets published.