### PR TITLE
ci: prove a published version is installable by a stranger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -177,6 +177,45 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # `npm publish` exiting 0 does not mean anyone can install it.
+      #
+      # A scoped package defaults to RESTRICTED. When 1.0.2 first went out the
+      # log read `+ @orcarouter/code-review@1.0.2` and the job was green, while
+      # the registry 404'd and the package page 403'd for everyone outside the
+      # org — despite both `--access public` and `publishConfig.access`.
+      #
+      # So: assert it, then prove it. `npm access set` is idempotent and fixes
+      # the state; the anonymous fetch is what actually decides, because it asks
+      # the question a user asks — can a stranger install this?
+      - name: Force public access
+        if: steps.check.outputs.needed == 'true'
+        continue-on-error: true # the verification below is the real gate
+        run: npm access set status=public "${{ steps.check.outputs.name }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify the published version is installable by a stranger
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          set -uo pipefail
+          NAME='${{ steps.check.outputs.name }}'
+          VERSION='${{ steps.check.outputs.version }}'
+          # No auth header here on purpose — an authenticated read would succeed
+          # against a private package and prove nothing.
+          URL="https://registry.npmjs.org/$(node -pe 'encodeURIComponent(process.argv[1])' "$NAME")/$VERSION"
+          for attempt in 1 2 3 4 5 6; do
+            CODE=$(curl -sS -o /dev/null -w '%{http_code}' "$URL" || echo 000)
+            echo "attempt $attempt: HTTP $CODE"
+            if [ "$CODE" = "200" ]; then
+              echo "$NAME@$VERSION is publicly installable"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::$NAME@$VERSION published but is not anonymously readable (HTTP $CODE)."
+          echo "::error::Scoped packages default to restricted. Fix with: npm access set status=public $NAME"
+          exit 1
+
       - name: Summary
         if: steps.check.outputs.needed == 'true'
         run: |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -104,6 +104,22 @@ Five gates run before the point of no return, and each one fails the job:
    own `node_modules/.bin` shim, asserting it prints the expected version and
    that `skill list` produces the catalog.
 
+And one gate *after* publishing, because that is the only place it can be
+checked:
+
+6. The new version is fetched from the registry **anonymously** and must return
+   200. `npm publish` exiting 0 does not mean anyone can install what it
+   shipped.
+
+Gate 6 exists because `@orcarouter/code-review@1.0.2` published green and was
+unreachable. Scoped packages default to **restricted**, and it landed that way
+despite both `--access public` and `publishConfig.access` — the log read
+`+ @orcarouter/code-review@1.0.2` while the registry 404'd and the package page
+403'd for everyone outside the org. The job now runs `npm access set
+status=public` (idempotent, soft-fail) and then proves the result with an
+unauthenticated fetch. The fetch is what decides: an authenticated read would
+succeed against a private package and prove nothing.
+
 Gate 5 exists because 1.0.0 shipped a CLI that did nothing. npm installs a `bin`
 as a **symlink**, so `argv[1]` is the link while `import.meta.url` is its
 target; the entry-point guard compared the two without `realpath` and was false


### PR DESCRIPTION
`npm publish` exiting 0 does not mean anyone can install what it shipped.

## What happened

`@orcarouter/code-review@1.0.2` published **green**. The log read `+ @orcarouter/code-review@1.0.2`, all five gates passed, the job was a tick.

```
$ curl -o /dev/null -w '%{http_code}' https://registry.npmjs.org/@orcarouter%2fcode-review
404
$ curl -o /dev/null -w '%{http_code}' https://www.npmjs.com/package/@orcarouter/code-review
403
```

Scoped packages default to **restricted**, and it landed that way despite *both* `--access public` on the publish command and `publishConfig.access` in `package.json`.

## Fix

Two steps after publish:

**`npm access set status=public`** — idempotent, and it *fixes* the state rather than only complaining about it. Soft-fail, because the next step is the real gate.

**An unauthenticated fetch of the exact version**, retried for a minute to absorb CDN lag. Anonymous on purpose: an authenticated read succeeds against a private package and would prove nothing. This asks the question a user asks — *can a stranger install this?*

On failure the error carries the fix:

```
::error::…published but is not anonymously readable (HTTP 404).
::error::Scoped packages default to restricted. Fix with: npm access set status=public …
```

## The pattern

Third time in this series a green step hid a broken result:

| Shipped | Looked like | Actually |
| --- | --- | --- |
| 1.0.0 | published fine | CLI exited 0 printing nothing — npm's bin symlink |
| 1.0.2 | published fine | not fetchable by anyone outside the org |

Same shape both times: the exit code was checked, the observable outcome was not. Gates 5 and 6 exist to check outcomes — install it and run it; fetch it as a stranger.

## No version bump

CI-only, so merging triggers no publish. 1.0.2 is already on the registry and only needs its access flipped — a one-time manual command, since the workflow's `needed` check will correctly skip an already-published version.