### PR TITLE
ci: give the public-readability check three minutes, not one

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -203,17 +203,23 @@ jobs:
           # No auth header here on purpose — an authenticated read would succeed
           # against a private package and prove nothing.
           URL="https://registry.npmjs.org/$(node -pe 'encodeURIComponent(process.argv[1])' "$NAME")/$VERSION"
-          for attempt in 1 2 3 4 5 6; do
+          # Three minutes. A brand-new version document takes a while to reach
+          # the public CDN edge — 1.1.0 needed longer than the first sixty
+          # seconds this waited, and failed a build that had shipped correctly.
+          # A restricted package and an unpropagated one both answer 404, so
+          # the status code cannot shorten this; only time can.
+          for attempt in $(seq 1 15); do
             CODE=$(curl -sS -o /dev/null -w '%{http_code}' "$URL" || echo 000)
-            echo "attempt $attempt: HTTP $CODE"
+            echo "attempt $attempt/15: HTTP $CODE"
             if [ "$CODE" = "200" ]; then
               echo "$NAME@$VERSION is publicly installable"
               exit 0
             fi
-            sleep 10
+            sleep 12
           done
-          echo "::error::$NAME@$VERSION published but is not anonymously readable (HTTP $CODE)."
-          echo "::error::Scoped packages default to restricted. Fix with: npm access set status=public $NAME"
+          echo "::error::$NAME@$VERSION published but is still not anonymously readable after 3 minutes (HTTP $CODE)."
+          echo "::error::Either it is restricted — fix with: npm access set status=public $NAME"
+          echo "::error::or the CDN is unusually slow. Check $URL by hand before assuming the former."
           exit 1
 
       - name: Summary

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -108,8 +108,13 @@ And one gate *after* publishing, because that is the only place it can be
 checked:
 
 6. The new version is fetched from the registry **anonymously** and must return
-   200. `npm publish` exiting 0 does not mean anyone can install what it
-   shipped.
+   200, retried for three minutes. `npm publish` exiting 0 does not mean anyone
+   can install what it shipped.
+
+   The window is that long because a restricted package and one that simply has
+   not reached the CDN edge yet both answer 404 — the status code cannot tell
+   them apart, so only waiting can. A red gate 6 therefore means *check the URL
+   by hand* before assuming the package is private.
 
 Gate 6 exists because `@orcarouter/code-review@1.0.2` published green and was
 unreachable. Scoped packages default to **restricted**, and it landed that way


### PR DESCRIPTION
Gate 6 failed `1.1.0` — which had published correctly.

```
Publish                                        ✓
Force public access                            ✓
Verify the published version is installable    ✗
```

The version document had not reached the public CDN edge inside the sixty seconds the check waited. Two minutes later:

```
registry root      → 200
1.1.0 version doc  → 200
dist-tags.latest   → 1.1.0
npx @orcarouter/code-review@1.1.0 --version → 1.1.0
```

## Why not shorten it another way

A **restricted** package and one that simply **has not propagated** both answer `404` anonymously. The status code cannot tell them apart, so nothing but waiting can. Fifteen attempts, twelve seconds apart.

The error now says so, instead of asserting the package is private:

```
::error::…still not anonymously readable after 3 minutes (HTTP 404).
::error::Either it is restricted — fix with: npm access set status=public …
::error::or the CDN is unusually slow. Check <url> by hand before assuming the former.
```

## Keeping it strict

Tempting to downgrade gate 6 to a warning after it cried wolf. That's the wrong lesson — it caught a genuinely unreachable `1.0.2`, which every other gate passed. A slower green beats a missed silent failure.

## No version bump

CI-only. 1.1.0 is already published, so the `needed` check skips the publish path entirely and this merges green.