### PR TITLE
ci: verify against the packument, the document npm actually installs from

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -200,26 +200,39 @@ jobs:
           set -uo pipefail
           NAME='${{ steps.check.outputs.name }}'
           VERSION='${{ steps.check.outputs.version }}'
-          # No auth header here on purpose — an authenticated read would succeed
-          # against a private package and prove nothing.
-          URL="https://registry.npmjs.org/$(node -pe 'encodeURIComponent(process.argv[1])' "$NAME")/$VERSION"
-          # Three minutes. A brand-new version document takes a while to reach
-          # the public CDN edge — 1.1.0 needed longer than the first sixty
-          # seconds this waited, and failed a build that had shipped correctly.
-          # A restricted package and an unpropagated one both answer 404, so
-          # the status code cannot shorten this; only time can.
-          for attempt in $(seq 1 15); do
-            CODE=$(curl -sS -o /dev/null -w '%{http_code}' "$URL" || echo 000)
-            echo "attempt $attempt/15: HTTP $CODE"
-            if [ "$CODE" = "200" ]; then
-              echo "$NAME@$VERSION is publicly installable"
+          ENCODED=$(node -pe 'encodeURIComponent(process.argv[1])' "$NAME")
+
+          # Fetch the PACKUMENT, not the per-version document.
+          #
+          # `npm install` reads the packument and picks a version out of it, so
+          # that is the document whose freshness actually decides whether a
+          # stranger can install. The /<name>/<version> route is a colder path:
+          # it 404'd for more than three minutes after two correct publishes,
+          # failing builds that had shipped fine. Checking the wrong document
+          # was the bug, not the timeout.
+          #
+          # No auth header on purpose — an authenticated read succeeds against a
+          # restricted package and would prove nothing.
+          for attempt in $(seq 1 20); do
+            BODY=$(curl -sS -H 'Cache-Control: no-cache' "https://registry.npmjs.org/$ENCODED" || echo '')
+            FOUND=$(printf '%s' "$BODY" | node -pe '
+              try {
+                const d = JSON.parse(require("fs").readFileSync(0, "utf8"));
+                d.versions?.[process.argv[1]] ? "yes" : "no";
+              } catch { "no" }
+            ' "$VERSION" 2>/dev/null || echo no)
+
+            if [ "$FOUND" = "yes" ]; then
+              echo "$NAME@$VERSION is in the public packument — installable"
               exit 0
             fi
-            sleep 12
+            echo "attempt $attempt/20: not in the public packument yet"
+            sleep 15
           done
-          echo "::error::$NAME@$VERSION published but is still not anonymously readable after 3 minutes (HTTP $CODE)."
+
+          echo "::error::$NAME@$VERSION published but is absent from the public packument after 5 minutes."
           echo "::error::Either it is restricted — fix with: npm access set status=public $NAME"
-          echo "::error::or the CDN is unusually slow. Check $URL by hand before assuming the former."
+          echo "::error::or the CDN is unusually slow. Check https://registry.npmjs.org/$ENCODED by hand."
           exit 1
 
       - name: Summary

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -107,14 +107,20 @@ Five gates run before the point of no return, and each one fails the job:
 And one gate *after* publishing, because that is the only place it can be
 checked:
 
-6. The new version is fetched from the registry **anonymously** and must return
-   200, retried for three minutes. `npm publish` exiting 0 does not mean anyone
-   can install what it shipped.
+6. The new version must appear in the **public packument**, fetched
+   anonymously and retried for five minutes. `npm publish` exiting 0 does not
+   mean anyone can install what it shipped.
 
-   The window is that long because a restricted package and one that simply has
-   not reached the CDN edge yet both answer 404 — the status code cannot tell
-   them apart, so only waiting can. A red gate 6 therefore means *check the URL
-   by hand* before assuming the package is private.
+   It polls `registry.npmjs.org/<name>` — the document `npm install` actually
+   reads to pick a version — rather than the `/<name>/<version>` route. That
+   distinction is not cosmetic: the per-version route stayed 404 for over three
+   minutes after two correct publishes and failed both builds. Checking a
+   document nobody installs from was the bug; the timeout was a symptom.
+
+   Anonymous on purpose — an authenticated read succeeds against a restricted
+   package and proves nothing. A restricted package and an unpropagated one
+   look alike, so a red gate 6 still means *check the URL by hand* before
+   concluding the package is private.
 
 Gate 6 exists because `@orcarouter/code-review@1.0.2` published green and was
 unreachable. Scoped packages default to **restricted**, and it landed that way


### PR DESCRIPTION
Gate 6 has now failed **two correct publishes** — 1.1.0 and 1.2.0 — both public and installable minutes later.

```
Publish                                        ✓
Force public access                            ✓
Verify the published version is installable    ✗     ← wrong, twice
```

A gate that cries wolf two times out of three is not strict, it is broken.

## The timeout was a symptom

It polled `registry.npmjs.org/<name>/<version>` — a route **nothing in the install path touches**. `npm install` fetches the full packument and picks a version out of it. That document goes live far sooner; the per-version route stayed 404 for over three minutes after both publishes.

I widened the window after the first failure. That was treating the symptom. The fix is to check the document a user's install actually reads.

## Now

```bash
curl -sS -H 'Cache-Control: no-cache' "https://registry.npmjs.org/$ENCODED"
# → does .versions["1.2.0"] exist?
```

Verified against the live registry before shipping:

```
1.2.0 -> yes
9.9.9 -> no
```

Window is five minutes, but the point is the document, not the wait.

## Still anonymous

An authenticated read succeeds against a restricted package and proves nothing — which is exactly the failure gate 6 exists to catch, and did catch on 1.0.2 when the package really was unreachable. That property is unchanged.

## No version bump

CI-only. 1.2.0 is already published, so the `needed` check skips the publish path and this merges green.