### PR TITLE
docs(skill): the agent hands the API key to gh and never touches it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Skills for OrcaRouter products.",
-    "version": "1.2.0"
+    "version": "1.2.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orca-code-review",
   "description": "Set up, reconfigure, troubleshoot, and remove OrcaCode Review — AI pull-request review powered by OrcaRouter — in any GitHub repository.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Continuum-AI-Corp",
     "url": "https://github.com/Continuum-AI-Corp"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -200,26 +200,39 @@ jobs:
           set -uo pipefail
           NAME='${{ steps.check.outputs.name }}'
           VERSION='${{ steps.check.outputs.version }}'
-          # No auth header here on purpose — an authenticated read would succeed
-          # against a private package and prove nothing.
-          URL="https://registry.npmjs.org/$(node -pe 'encodeURIComponent(process.argv[1])' "$NAME")/$VERSION"
-          # Three minutes. A brand-new version document takes a while to reach
-          # the public CDN edge — 1.1.0 needed longer than the first sixty
-          # seconds this waited, and failed a build that had shipped correctly.
-          # A restricted package and an unpropagated one both answer 404, so
-          # the status code cannot shorten this; only time can.
-          for attempt in $(seq 1 15); do
-            CODE=$(curl -sS -o /dev/null -w '%{http_code}' "$URL" || echo 000)
-            echo "attempt $attempt/15: HTTP $CODE"
-            if [ "$CODE" = "200" ]; then
-              echo "$NAME@$VERSION is publicly installable"
+          ENCODED=$(node -pe 'encodeURIComponent(process.argv[1])' "$NAME")
+
+          # Fetch the PACKUMENT, not the per-version document.
+          #
+          # `npm install` reads the packument and picks a version out of it, so
+          # that is the document whose freshness actually decides whether a
+          # stranger can install. The /<name>/<version> route is a colder path:
+          # it 404'd for more than three minutes after two correct publishes,
+          # failing builds that had shipped fine. Checking the wrong document
+          # was the bug, not the timeout.
+          #
+          # No auth header on purpose — an authenticated read succeeds against a
+          # restricted package and would prove nothing.
+          for attempt in $(seq 1 20); do
+            BODY=$(curl -sS -H 'Cache-Control: no-cache' "https://registry.npmjs.org/$ENCODED" || echo '')
+            FOUND=$(printf '%s' "$BODY" | node -pe '
+              try {
+                const d = JSON.parse(require("fs").readFileSync(0, "utf8"));
+                d.versions?.[process.argv[1]] ? "yes" : "no";
+              } catch { "no" }
+            ' "$VERSION" 2>/dev/null || echo no)
+
+            if [ "$FOUND" = "yes" ]; then
+              echo "$NAME@$VERSION is in the public packument — installable"
               exit 0
             fi
-            sleep 12
+            echo "attempt $attempt/20: not in the public packument yet"
+            sleep 15
           done
-          echo "::error::$NAME@$VERSION published but is still not anonymously readable after 3 minutes (HTTP $CODE)."
+
+          echo "::error::$NAME@$VERSION published but is absent from the public packument after 5 minutes."
           echo "::error::Either it is restricted — fix with: npm access set status=public $NAME"
-          echo "::error::or the CDN is unusually slow. Check $URL by hand before assuming the former."
+          echo "::error::or the CDN is unusually slow. Check https://registry.npmjs.org/$ENCODED by hand."
           exit 1
 
       - name: Summary

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -107,14 +107,20 @@ Five gates run before the point of no return, and each one fails the job:
 And one gate *after* publishing, because that is the only place it can be
 checked:
 
-6. The new version is fetched from the registry **anonymously** and must return
-   200, retried for three minutes. `npm publish` exiting 0 does not mean anyone
-   can install what it shipped.
+6. The new version must appear in the **public packument**, fetched
+   anonymously and retried for five minutes. `npm publish` exiting 0 does not
+   mean anyone can install what it shipped.
 
-   The window is that long because a restricted package and one that simply has
-   not reached the CDN edge yet both answer 404 — the status code cannot tell
-   them apart, so only waiting can. A red gate 6 therefore means *check the URL
-   by hand* before assuming the package is private.
+   It polls `registry.npmjs.org/<name>` — the document `npm install` actually
+   reads to pick a version — rather than the `/<name>/<version>` route. That
+   distinction is not cosmetic: the per-version route stayed 404 for over three
+   minutes after two correct publishes and failed both builds. Checking a
+   document nobody installs from was the bug; the timeout was a symptom.
+
+   Anonymous on purpose — an authenticated read succeeds against a restricted
+   package and proves nothing. A restricted package and an unpropagated one
+   look alike, so a red gate 6 still means *check the URL by hand* before
+   concluding the package is private.
 
 Gate 6 exists because `@orcarouter/code-review@1.0.2` published green and was
 unreachable. Scoped packages default to **restricted**, and it landed that way

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcarouter/code-review",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "One-command installer for OrcaCode Review — AI pull-request review powered by OrcaRouter.",
   "bin": {
     "orcacode-review": "bin/orcacode-review.mjs"

--- a/scripts/installer.test.mjs
+++ b/scripts/installer.test.mjs
@@ -188,3 +188,28 @@ test("every npx invocation in the README names the real package", () => {
     assert.equal(name, PKG.name, `stale package name in README: npx ${name}`);
   }
 });
+
+// ------------------------------------------------------- skill safety rules ---
+
+const SKILL = fs.readFileSync(
+  new URL("../skills/setup-orca-code-review/SKILL.md", import.meta.url),
+  "utf8",
+);
+
+test("the skill tells the agent to hand the API key to gh, not handle it", () => {
+  // The one instruction that must never be softened. An agent that reads the
+  // key to be helpful puts it in the transcript, permanently.
+  assert.match(SKILL, /gh secret set ORCAROUTER_API_KEY/);
+  assert.match(SKILL, /[Nn]ever.{0,80}paste the key into the chat/s);
+  assert.match(SKILL, /\bps\b/, "the argv/ps rationale is missing — rules without reasons get edited away");
+});
+
+test("the skill closes by listing the key as an outstanding user action", () => {
+  const report = SKILL.slice(SKILL.indexOf("### 8."), SKILL.indexOf("## Reconfigure"));
+  assert.match(report, /gh secret set ORCAROUTER_API_KEY/, "the final step does not repeat the gh command");
+  assert.match(report, /copy-pasteable/i);
+});
+
+test("the skill refuses to call an install complete without the secret", () => {
+  assert.match(SKILL, /[Dd]o not report the\s+install as complete while the secret is missing/s);
+});

--- a/skills/setup-orca-code-review/SKILL.md
+++ b/skills/setup-orca-code-review/SKILL.md
@@ -101,27 +101,41 @@ from spending your quota with `/orcacode-review`.
 
 Show the user the final file before committing.
 
-### 4. Add the API key secret
+### 4. Have the user add the API key — with `gh`, themselves
 
 The secret must be named exactly `ORCAROUTER_API_KEY`.
 
-**Never ask the user to paste the key into the chat, and never read it from a file.**
-It would land in the transcript. Instead, tell them to run it themselves in this session:
+This is the one step you do **not** perform. Stop, hand the user this command,
+and wait for them to confirm they have run it:
 
 ```
 ! gh secret set ORCAROUTER_API_KEY --repo <owner/name>
 ```
 
-`gh` prompts for the value and it never reaches you. Without `gh`, send them to
-`https://github.com/<owner>/<name>/settings/secrets/actions/new`.
+`gh` prompts for the value on their terminal, so the key goes from their
+keyboard straight to GitHub. It never passes through you.
+
+**Never** ask them to paste the key into the chat, read it out of a file or an
+env var, or pass it on a command line. A pasted key is in the transcript
+forever; a key in `argv` is visible to every process on the machine via `ps`.
+There is no version of this you can do "carefully" — the only safe handling is
+not handling it.
 
 They can create or copy a key at <https://www.orcarouter.ai/console/token>.
 
-Then verify it exists without revealing it:
+Without `gh`, send them to
+`https://github.com/<owner>/<name>/settings/secrets/actions/new` and have them
+add it in the browser.
+
+Then confirm it exists without ever seeing its value:
 
 ```bash
 gh secret list --repo <owner/name> | grep ORCAROUTER_API_KEY
 ```
+
+If it is not there yet, do not continue to the test PR — the run will fail on
+auth and the failure will look like a configuration bug rather than a missing
+key. Wait, or skip to step 8 and list it as outstanding.
 
 ### 5. Enable the app
 
@@ -150,11 +164,24 @@ gh api -X PATCH repos/<owner>/<name>/branches/<default>/protection/required_stat
 
 Confirm before running — branch protection changes affect everyone on the repo.
 
-### 8. Report
+### 8. Report, and close on what they still owe
 
 Tell the user, concretely: the workflow path, the settings you chose, whether the
 secret and required check are in place, and the result of the test run. If any step
-was skipped (no `gh`, protection not applied), say which and what they still owe.
+was skipped (no `gh`, protection not applied), say which.
+
+**End the message with their outstanding actions as copy-pasteable commands** —
+not prose describing them. Anything you could not do yourself belongs here, and
+the API key is almost always on the list because you are not allowed to do it:
+
+```
+! gh secret set ORCAROUTER_API_KEY --repo <owner/name>
+```
+
+Re-check with `gh secret list` before claiming it is done. Do not report the
+install as complete while the secret is missing: the workflow is in place but
+every run will fail on auth, and "installed" would be a lie the user only finds
+out about on their next PR.
 
 ## Reconfigure
 


### PR DESCRIPTION
Makes the one rule that must not be softened explicit, and repeats it where the user will act on it.

## Step 4 — the step the agent does *not* do

It stops, hands over the command, and waits:

```
! gh secret set ORCAROUTER_API_KEY --repo <owner/name>
```

`gh` prompts on the user's own terminal, so the key goes keyboard-to-GitHub without passing through the agent.

The *why* is now in the file, not just the *what*:

> A pasted key is in the transcript forever; a key in `argv` is visible to every process on the machine via `ps`. There is no version of this you can do "carefully" — the only safe handling is not handling it.

A rule without its reason is a rule the next editor deletes.

It also stops the flow: if the secret is not set, don't open the test PR. The run would fail on auth and read as a configuration bug rather than a missing key.

## Step 8 — close on what they owe

Outstanding actions as **copy-pasteable commands**, not prose describing them — and the `gh` command is almost always among them, precisely because the agent is not allowed to do it.

Plus: never report the install as complete while the secret is missing. The workflow would be in place with every run failing on auth, so "installed" would be a lie the user only discovers on their next PR.

## Three tests

Prose drifts. These don't:

- the `gh secret set` command and the never-paste rule are both present, *including* the `ps`/argv rationale
- step 8 specifically repeats the command
- the refusal to call an install complete without the secret survives

385 tests passing. 1.2.1 — merging publishes it.