### PR TITLE
feat: one review tier, and a report_on severity filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,24 +9,23 @@ Automatically review every pull request, post findings directly on the affected 
 ## How it works
 
 ```text
-PR → Fast Review → Strong Review → Merge Gate
-        │               │
-     P0/P1?           P0/P1?
-        ↓               ↓
-      BLOCK           BLOCK
+PR → Review → Merge Gate
+        │
+     P0/P1?
+        ↓
+      BLOCK
 ```
 
-Every PR starts with a fast, low-cost model. Once clear of P0/P1 issues, OrcaCode automatically escalates to a stronger model for the final review.
+Every push gets one review. Findings post on the affected lines, and P0/P1 blocks the merge.
 
-**You choose the models in OrcaRouter. OrcaCode handles the review.**
+**You choose the model in OrcaRouter. OrcaCode handles the review.**
 
 ### What you get
 
 * 🔍 Automatic review on every PR
 * 💬 Inline P0 / P1 / P2 findings
 * 🛑 Merge gate for serious issues
-* ⚡ Fast → strong model cascade
-* 🧠 Choose your own review models
+* 🧠 Choose your own review model
 * 🎯 Precision filtering to reduce false positives
 * 🔒 OrcaRouter guardrails + security policies
 * 🔄 Re-run anytime with `/orcacode-review`
@@ -163,10 +162,10 @@ Customize the rubric and blocking policy from **OrcaRouter → Apps → OrcaCode
 
 Manage OrcaCode from **OrcaRouter → Apps → OrcaCode Review**:
 
-* **Models** — choose your fast + strong reviewers
+* **Model** — choose your reviewer
 * **Review mode** — every push, ready for review, or on demand
 * **Merge policy** — choose which severities block
-* **Exhaustive review** — run additional strong-model passes
+* **Exhaustive review** — run additional passes over the same diff
 * **Quiet mode** — keep P2 findings in the summary
 * **Custom rubric** — define your own review rules
 * **Guardrails** — add security and policy checks

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Automatically review every pull request, post findings directly on the affected lines, and block serious issues from merging.
 
-**P0/P1 → ❌ Block** · **P2 → 💬 Comment** · **Clean → ✅ Pass**
+**P0/P1 → ❌ Block** · **Findings → 💬 Comment** · **Clean → ✅ Pass**
 
 ## How it works
 
@@ -23,7 +23,7 @@ Every push gets one review. Findings post on the affected lines, and P0/P1 block
 ### What you get
 
 * 🔍 Automatic review on every PR
-* 💬 Inline P0 / P1 / P2 findings
+* 💬 Inline findings on the affected lines
 * 🛑 Merge gate for serious issues
 * 🧠 Choose your own review model
 * 🎯 Precision filtering to reduce false positives
@@ -148,13 +148,24 @@ OrcaCode automatically reviews new PRs and pushes, posts findings inline, and re
 
 ## Severity
 
-| Severity | Meaning            | Result     |
-| -------- | ------------------ | ---------- |
-| **P0**   | Critical / blocker | ❌ Block    |
-| **P1**   | High severity      | ❌ Block    |
-| **P2**   | Advisory           | 💬 Comment |
+| Severity | Meaning              | Merge gate | Posted inline          |
+| -------- | -------------------- | ---------- | ---------------------- |
+| **P0**   | Critical / blocker   | ❌ Block    | Always                 |
+| **P1**   | High severity        | ❌ Block    | Always                 |
+| **P2**   | Advisory             | ✅ Pass     | Per Report severities  |
+| **P3**   | Nit / style          | ✅ Pass     | Per Report severities  |
 
-Customize the rubric and blocking policy from **OrcaRouter → Apps → OrcaCode Review**.
+Two independent settings, and the defaults above are the shipped ones:
+
+* **Merge policy** decides what blocks.
+* **Report severities** decides what gets posted on the diff.
+
+A severity that blocks is always posted, whatever Report severities says — a
+failing check with nothing on the diff explaining it is worse than a noisy one.
+Narrowing Report severities never changes the gate, and the PR summary always
+counts every finding, so a muted P2 still shows up there.
+
+Customize the rubric and both policies from **OrcaRouter → Apps → OrcaCode Review**.
 
 ---
 
@@ -165,6 +176,7 @@ Manage OrcaCode from **OrcaRouter → Apps → OrcaCode Review**:
 * **Model** — choose your reviewer
 * **Review mode** — every push, ready for review, or on demand
 * **Merge policy** — choose which severities block
+* **Report severities** — choose which severities post on the diff
 * **Exhaustive review** — run additional passes over the same diff
 * **Quiet mode** — keep P2 findings in the summary
 * **Custom rubric** — define your own review rules

--- a/action.yml
+++ b/action.yml
@@ -702,8 +702,9 @@ runs:
         # $RUNNER_TEMP is runner-controlled and reset per job.
         RESULT: ${{ runner.temp }}/result.json
         REVIEW_LOG: ${{ runner.temp }}/review.log
-        # Per-tier snapshots of $RESULT (which the escalation pass overwrites):
-        # the report steps below need each tier's own severity counts.
+        # An unfiltered snapshot of $RESULT for the run report: it has to carry
+        # what the review FOUND, and $RESULT itself is the input to the display
+        # chain (report_on then quiet) further down.
         RESULT_FINAL: ${{ runner.temp }}/result-final.json
         # Exhaustive-mode scratch: each extra engine pass lands in
         # $RESULT_EXTRA and is deduped into $RESULT via $RESULT_MERGED.
@@ -1347,6 +1348,45 @@ runs:
           const newBody = injectSummary(pr.body, summaryMd);
           if (newBody !== (pr.body || '')) {
             await github.rest.pulls.update({ ...repo, pull_number: num, body: newBody });
+          }
+
+    # MIGRATION CLEANUP, and deletable once no open PR predates the single-tier
+    # release. An older version created the repository label `orca-review:strong`
+    # and attached it to a PR the moment it was promoted, to carry the tier
+    # between runs. Nothing reads or writes it now, so a PR promoted before the
+    # upgrade keeps a label asserting it sits in a tier that no longer exists —
+    # state this action created and would otherwise abandon on the user's PR.
+    #
+    # BLIND remove, not list-then-remove. Reading the labels is the paginated
+    # call the single-tier change deleted, and paying it on every run to find out
+    # whether a migration artifact is present costs more than the removal it
+    # guards. A 404 means the label was never there, which is the normal case.
+    #
+    # Placed BEFORE the gate on purpose: the gate exits non-zero on a blocking
+    # finding, and a blocked PR is exactly the kind that was promoted.
+    - name: Detach the retired tier label
+      if: steps.settings.outputs.decision != 'skip' && steps.guard.outputs.decision != 'skip'
+      continue-on-error: true
+      uses: actions/github-script@v7
+      env:
+        PR_NUMBER: ${{ steps.pr.outputs.number }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const num = Number(process.env.PR_NUMBER);
+          if (!Number.isInteger(num) || num <= 0) return;
+          try {
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: num,
+              name: 'orca-review:strong',
+            });
+            core.info('Removed the retired orca-review:strong label.');
+          } catch (e) {
+            // 404: no such label on this PR (or not in the repo at all) — the
+            // normal case for anything opened after the upgrade.
+            if (e.status !== 404) throw e;
           }
 
     - name: Enforce severity gate

--- a/action.yml
+++ b/action.yml
@@ -64,9 +64,11 @@ inputs:
     default: "orcarouter/code-review"
   fix-first:
     description: >-
-      Severities the review is told to propose a concrete fix for first. Also
-      stops further exhaustive passes once one is found. Does not block the
-      merge on its own — that is block-on.
+      Severities that stop an exhaustive review early: once a pass has found
+      one, no further passes are added, because that finding is what to fix
+      first. NO EFFECT unless exhaustive is on. It does not change what the
+      reviewer is asked to look for, and it does not block the merge — that
+      is block-on.
     required: false
     default: "P0,P1"
   block-on:
@@ -200,8 +202,14 @@ runs:
     - name: Clear stale run files
       shell: bash
       run: |
+        # result-cheap/result-strong are the pre-single-tier names, kept here on
+        # purpose: a reused self-hosted runner hard-cancelled under the older
+        # action still has them, and they hold finding text and source snippets.
+        # This step exists for exactly the files an earlier cleanup never
+        # reached, so renaming them out of the list would strand them.
         rm -f "$RUNNER_TEMP/result.json" "$RUNNER_TEMP/review.log" \
           "$RUNNER_TEMP/result-final.json" "$RUNNER_TEMP/result-reported.json" \
+          "$RUNNER_TEMP/result-cheap.json" "$RUNNER_TEMP/result-strong.json" \
           "$RUNNER_TEMP/result-posted.json" "$RUNNER_TEMP/result-extra.json" \
           "$RUNNER_TEMP/result-merged.json" \
           "$RUNNER_TEMP/cr-settings.json" "$RUNNER_TEMP/cr-rubric.md" \
@@ -1096,15 +1104,20 @@ runs:
         RESULT: ${{ runner.temp }}/result.json
         RESULT_REPORTED: ${{ runner.temp }}/result-reported.json
       run: |
-        # --show only when there IS a value: an absent flag means "no setting to
-        # apply" and the script passes everything through, while an empty one
-        # legitimately means "only what blocks". Collapsing the two would hide
-        # findings whenever the settings fetch came back thin.
-        if [ -n "$REPORT_ON" ]; then
-          node "$REPORT_FILTER" "$RESULT"             --show "$REPORT_ON" --block-on "$BLOCK_ON" --out "$RESULT_REPORTED"
-        else
-          node "$REPORT_FILTER" "$RESULT" --out "$RESULT_REPORTED"
-        fi
+        # ALWAYS --show, including when it is empty. The script reads an ABSENT
+        # flag as "no setting to apply" and passes everything through, and an
+        # EMPTY one as "publish only what blocks" — two different answers, and
+        # only one of them can be right here. The settings step always emits a
+        # value: the dashboard path forwards what was configured, and the
+        # disabled path writes every severity explicitly. So an empty value
+        # arriving here can only be the configured "show only what blocks",
+        # and guarding on `-n` published everything instead.
+        #
+        # There is no path where this is empty because nothing wrote it: if the
+        # settings step fails outright it fails the job, having no
+        # continue-on-error.
+        node "$REPORT_FILTER" "$RESULT" \
+          --show "$REPORT_ON" --block-on "$BLOCK_ON" --out "$RESULT_REPORTED"
 
     - name: Quiet mode filter
       if: steps.settings.outputs.decision != 'skip' && steps.guard.outputs.decision != 'skip'
@@ -1259,7 +1272,6 @@ runs:
         INJECT_SCRIPT: ${{ github.action_path }}/scripts/inject-summary.mjs
         GATE: ${{ github.action_path }}/scripts/gate.mjs
         BLOCK_ON: ${{ steps.settings.outputs.block_on }}
-        FIX_FIRST: ${{ steps.settings.outputs.fix_first }}
         QUIET: ${{ steps.settings.outputs.quiet }}
         PASSES: ${{ steps.review.outputs.passes }}
       with:
@@ -1344,7 +1356,6 @@ runs:
         BRAND: ${{ inputs.brand }}
         # Effective values after the settings/input precedence rule.
         BLOCK_ON: ${{ steps.settings.outputs.block_on }}
-        FIX_FIRST: ${{ steps.settings.outputs.fix_first }}
         GATE: ${{ github.action_path }}/scripts/gate.mjs
         # ALWAYS the unfiltered result — quiet mode never weakens the gate.
         RESULT: ${{ runner.temp }}/result.json

--- a/action.yml
+++ b/action.yml
@@ -1350,45 +1350,6 @@ runs:
             await github.rest.pulls.update({ ...repo, pull_number: num, body: newBody });
           }
 
-    # MIGRATION CLEANUP, and deletable once no open PR predates the single-tier
-    # release. An older version created the repository label `orca-review:strong`
-    # and attached it to a PR the moment it was promoted, to carry the tier
-    # between runs. Nothing reads or writes it now, so a PR promoted before the
-    # upgrade keeps a label asserting it sits in a tier that no longer exists —
-    # state this action created and would otherwise abandon on the user's PR.
-    #
-    # BLIND remove, not list-then-remove. Reading the labels is the paginated
-    # call the single-tier change deleted, and paying it on every run to find out
-    # whether a migration artifact is present costs more than the removal it
-    # guards. A 404 means the label was never there, which is the normal case.
-    #
-    # Placed BEFORE the gate on purpose: the gate exits non-zero on a blocking
-    # finding, and a blocked PR is exactly the kind that was promoted.
-    - name: Detach the retired tier label
-      if: steps.settings.outputs.decision != 'skip' && steps.guard.outputs.decision != 'skip'
-      continue-on-error: true
-      uses: actions/github-script@v7
-      env:
-        PR_NUMBER: ${{ steps.pr.outputs.number }}
-      with:
-        github-token: ${{ inputs.github-token }}
-        script: |
-          const num = Number(process.env.PR_NUMBER);
-          if (!Number.isInteger(num) || num <= 0) return;
-          try {
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: num,
-              name: 'orca-review:strong',
-            });
-            core.info('Removed the retired orca-review:strong label.');
-          } catch (e) {
-            // 404: no such label on this PR (or not in the repo at all) — the
-            // normal case for anything opened after the upgrade.
-            if (e.status !== 404) throw e;
-          }
-
     - name: Enforce severity gate
       if: steps.settings.outputs.decision != 'skip' && steps.guard.outputs.decision != 'skip'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -3,28 +3,23 @@
 # Consumers reference this with `uses:` instead of copying the folder; see
 # workflows/orca-code-review.yml for the ~15-line example workflow.
 #
-# Single-tier review (gpt-5.5): one review pass per run. The cheap->strong
-# cascade was retired after testing showed the cheap tier added no value online
-# — it fails closed on large diffs and otherwise just escalates anyway, taxing
-# every PR with latency for no decision. Size-based front routing (small->cheap,
-# large->strong, decided up front) is a planned later optimization and is also
-# single-pass, so this design stays forward-compatible. Findings post as inline
-# PR comments and a severity gate can fail the check to block the merge.
+# One review pass per pull-request push. Findings post as inline PR comments and
+# a severity gate can fail the check to block the merge.
 #
 # Model selection is NOT hardcoded here. The action emits raw facts
-# (x-cr-prev-tier / x-cr-prev-p0p1); it injects the strong-tier facts so the
-# router picks the single model. OCR can't send custom headers, so an in-job
-# loopback proxy (scripts/fact-proxy.mjs) stamps those facts onto OCR's
-# requests; the workspace router's DSL recipe (recipes/code-review.dsl.yaml)
-# maps them to the concrete model. The facts and rule shape are preserved so a
-# future size-based front-routing policy can re-diverge without an Action change.
+# (x-cr-prev-tier / x-cr-prev-p0p1) and never names a model; OCR cannot send
+# custom headers, so an in-job loopback proxy (scripts/fact-proxy.mjs) stamps
+# those facts onto its requests and the workspace router's DSL recipe
+# (recipes/code-review.dsl.yaml) turns them into a concrete model. Changing which
+# model reviews your code is therefore a recipe edit in your own workspace, with
+# no Action version to bump.
 #
-# Around the cascade: dashboard settings (scripts/settings.mjs, fetched
+# Around the review: dashboard settings (scripts/settings.mjs, fetched
 # fail-open from the gateway; `settings: "false"` skips the fetch and makes
 # the workflow file authoritative) gate auto reviews (auto_review / trigger),
 # retune fix-first/block-on, and switch on quiet mode (P2 muted at posting via
 # scripts/quiet-filter.mjs — the gate/report still see true counts), an
-# exhaustive mode (extra engine passes on the strong tier only, deduped by
+# exhaustive mode (extra engine passes, deduped by
 # scripts/exhaustive-merge.mjs), and a server-side rubric override; an
 # oversized-diff guard (scripts/diff-guard.mjs) decides review/skip BEFORE the
 # engine ever runs (a skip posts a notice and, by default, FAILS the check so
@@ -62,13 +57,16 @@ inputs:
   router:
     description: >-
       OrcaRouter router alias (orcarouter/<name>) that owns model selection.
-      The action names no models: it injects the cascade's raw facts
-      (x-cr-prev-tier / x-cr-prev-p0p1) as headers and this router's DSL recipe
-      maps them to the cheap/strong model. See recipes/code-review.dsl.yaml.
+      The action names no models: it injects raw facts (x-cr-prev-tier /
+      x-cr-prev-p0p1) as headers and this router's DSL recipe turns them into a
+      concrete model. See recipes/code-review.dsl.yaml.
     required: false
     default: "orcarouter/code-review"
   fix-first:
-    description: "Severities that withhold the strong tier until fixed at the cheap tier."
+    description: >-
+      Severities the review is told to propose a concrete fix for first. Also
+      stops further exhaustive passes once one is found. Does not block the
+      merge on its own — that is block-on.
     required: false
     default: "P0,P1"
   block-on:
@@ -81,7 +79,7 @@ inputs:
       reviews (pull_request events). Empty = review everyone (default). On a
       PUBLIC repo, pull_request_target bypasses GitHub's fork-approval gate
       and the review key is wallet-metered, so an external user can trigger
-      paid cascades by opening PRs — set e.g.
+      paid reviews by opening PRs — set e.g.
       "OWNER,MEMBER,COLLABORATOR,CONTRIBUTOR" to auto-review only known
       contributors (others can still be reviewed on demand via
       /orcacode-review). Also set a wallet budget + alert on the key.
@@ -198,12 +196,12 @@ runs:
     # action writes there — above all policy-block.json, which the
     # always()-running "Surface guardrail / firewall block" step trusts and
     # would otherwise post as a false "merge is blocked" comment on a clean
-    # run whose cascade (and its own stale-file rm) never executed.
+    # run whose review step (and its own stale-file rm) never executed.
     - name: Clear stale run files
       shell: bash
       run: |
         rm -f "$RUNNER_TEMP/result.json" "$RUNNER_TEMP/review.log" \
-          "$RUNNER_TEMP/result-cheap.json" "$RUNNER_TEMP/result-strong.json" \
+          "$RUNNER_TEMP/result-final.json" "$RUNNER_TEMP/result-reported.json" \
           "$RUNNER_TEMP/result-posted.json" "$RUNNER_TEMP/result-extra.json" \
           "$RUNNER_TEMP/result-merged.json" \
           "$RUNNER_TEMP/cr-settings.json" "$RUNNER_TEMP/cr-rubric.md" \
@@ -257,16 +255,6 @@ runs:
           // in the workflow `if:`).
           core.setOutput('author_association', authorAssoc);
 
-          // Stateful tier: the PR carries an `orca-review:strong` label once it
-          // has been promoted to the strong model. No label means it is still on
-          // the cheap tier. One run uses exactly ONE model.
-          const labels = await github.paginate(
-            github.rest.issues.listLabelsOnIssue,
-            { owner: context.repo.owner, repo: context.repo.repo, issue_number: num, per_page: 100 },
-          );
-          const promoted = labels.some((l) => l.name === 'orca-review:strong');
-          core.setOutput('tier', promoted ? '1' : '0');
-          core.info(`PR #${num} review tier: ${promoted ? '1 (strong)' : '0 (cheap)'}`);
 
     # Lightweight 👀 acknowledgement so the requester sees the bot noticed the
     # trigger. Static one-shot (no update or removal). Fires early — before any
@@ -399,6 +387,10 @@ runs:
             echo "quiet=false"
             echo "fix_first=$INPUT_FIX_FIRST"
             echo "block_on=$INPUT_BLOCK_ON"
+            # Every severity: with the dashboard off there is no report_on to
+            # honour and the workflow file has no input for it, so display must
+            # not narrow on its own.
+            echo "report_on=P0,P1,P2,P3"
             echo "rubric_file="
             echo "decision=$DECISION"
             echo "reason=$REASON"
@@ -422,6 +414,12 @@ runs:
         QUIET=$(setting quiet false)
         FIX_FIRST=$(setting fix_first "P0,P1")
         BLOCK_ON=$(setting block_on "P0,P1")
+        # DISPLAY ONLY, and with no `with:` override on purpose: fix_first and
+        # block_on have workflow inputs because a repo may need to ENFORCE
+        # differently from the workspace default, whereas which severities a
+        # reader SEES is the workspace's call. Defaulting to every severity means
+        # a gateway that predates the field behaves exactly as before.
+        REPORT_ON=$(setting report_on "P0,P1,P2,P3")
         RUBRIC=$(setting rubric "")
 
         # PRECEDENCE (documented in the README): an explicit `with:` input that
@@ -445,7 +443,7 @@ runs:
         # while the author-allowlist spend guard inside it is identical in both
         # paths.
         gate_decision "$AUTO_REVIEW" "$TRIGGER" "$IS_DRAFT"
-        echo "settings: auto_review=$AUTO_REVIEW trigger=$TRIGGER exhaustive=$EXHAUSTIVE quiet=$QUIET fix_first=$FIX_FIRST block_on=$BLOCK_ON rubric=${RUBRIC_OUT:+custom} -> $DECISION ${REASON:+($REASON)}"
+        echo "settings: auto_review=$AUTO_REVIEW trigger=$TRIGGER exhaustive=$EXHAUSTIVE quiet=$QUIET fix_first=$FIX_FIRST block_on=$BLOCK_ON report_on=$REPORT_ON rubric=${RUBRIC_OUT:+custom} -> $DECISION ${REASON:+($REASON)}"
         {
           echo "auto_review=$AUTO_REVIEW"
           echo "trigger=$TRIGGER"
@@ -453,6 +451,7 @@ runs:
           echo "quiet=$QUIET"
           echo "fix_first=$FIX_FIRST"
           echo "block_on=$BLOCK_ON"
+          echo "report_on=$REPORT_ON"
           echo "rubric_file=$RUBRIC_OUT"
           echo "decision=$DECISION"
           echo "reason=$REASON"
@@ -637,12 +636,11 @@ runs:
         ENGINE_VERSION: ${{ inputs.engine-version }}
       run: npm install -g "@alibaba-group/open-code-review@${ENGINE_VERSION}"
 
-    - name: Review (stateful cost-tiered cascade)
-      id: cascade
+    - name: Review
+      id: review
       if: steps.settings.outputs.decision != 'skip' && steps.guard.outputs.decision != 'skip'
       shell: bash
       env:
-        TIER_STATE: ${{ steps.pr.outputs.tier }}
         ROUTER: ${{ inputs.router }}
         # Wall-clock ceiling for ONE engine pass; wrapped around `ocr review`
         # via GNU `timeout` inside run_pass. Passed as-is (units are minutes;
@@ -677,7 +675,7 @@ runs:
         PROXY: ${{ github.action_path }}/scripts/fact-proxy.mjs
         BRAND: ${{ inputs.brand }}
         # The real OrcaRouter endpoint. OCR does NOT talk to it directly: the
-        # in-job proxy stamps the cascade's facts as headers and forwards here.
+        # in-job proxy stamps the routing facts as headers and forwards here.
         ORCAROUTER_URL: ${{ inputs.orcarouter-url }}
         # Drive OCR entirely through env vars — its highest-priority config source.
         # Nothing is written to the shared ~/.opencodereview, so we neither leak a
@@ -698,8 +696,7 @@ runs:
         REVIEW_LOG: ${{ runner.temp }}/review.log
         # Per-tier snapshots of $RESULT (which the escalation pass overwrites):
         # the report steps below need each tier's own severity counts.
-        RESULT_CHEAP: ${{ runner.temp }}/result-cheap.json
-        RESULT_STRONG: ${{ runner.temp }}/result-strong.json
+        RESULT_FINAL: ${{ runner.temp }}/result-final.json
         # Exhaustive-mode scratch: each extra engine pass lands in
         # $RESULT_EXTRA and is deduped into $RESULT via $RESULT_MERGED.
         RESULT_EXTRA: ${{ runner.temp }}/result-extra.json
@@ -712,7 +709,7 @@ runs:
         METER: ${{ inputs.meter }}
         USAGE_FILE: ${{ runner.temp }}/cr-usage.jsonl
         # The proxy writes the guardrail/firewall reason here on a block; a later
-        # always()-step posts it to the PR (the cascade itself fails closed).
+        # always()-step posts it to the PR (the review step itself fails closed).
         POLICY_BLOCK: ${{ runner.temp }}/policy-block.json
       run: |
         set -e
@@ -720,7 +717,7 @@ runs:
         # Security: we run with secrets against the PR head on pull_request_target,
         # so never let PR-controlled config weaken the review. A fork could commit
         # `.opencodereview/rule.json` to exclude its own changed files or replace
-        # the built-in checks, yielding an empty result that passes/promotes as
+        # the built-in checks, yielding an empty result that passes as
         # clean. Drop it so OCR uses system defaults + our --background instruction.
         rm -rf .opencodereview
 
@@ -757,7 +754,7 @@ runs:
         export OCR_LLM_URL
 
         # Set the raw facts the DSL routes on for the NEXT review pass.
-        #   $1 = prev tier (cheap|strong), $2 = prev pass found a fix-first (true|false)
+        #   $1 = prev-tier fact, $2 = prev pass found a fix-first (true|false)
         set_facts() {
           printf '{"x-cr-prev-tier":"%s","x-cr-prev-p0p1":"%s"}' "$1" "$2" > "$FACTS_FILE"
         }
@@ -901,18 +898,17 @@ runs:
           node "$CHECK" "$1" "$rc"
         }
 
-        # One TIER: the mandatory first pass, then — exhaustive mode, on the
-        # STRONG (enforced) tier only — up to 2 extra engine passes over the
-        # same diff (LLM reviews aren't exhaustive in one pass), each deduped
-        # into $RESULT by exhaustive-merge.mjs. Cheap-tier extras would be
-        # waste: a clear cheap pass escalates and the same-run strong review
-        # supersedes it, and a held one wants its fix-first findings fixed
-        # before more depth. The loop also stops as soon as a fix-first
-        # finding is in hand — the gate blocks on what we already have — or a
-        # pass adds nothing new. So the enforced tier runs at most 3 engine
-        # passes total. PASSES counts this tier's passes for the summary.
-        #   $1 = log label, $2 = prev tier fact, $3 = prev fix-first fact,
-        #   $4 = extra passes allowed (true only on the strong tier)
+        # The mandatory first pass, then — in exhaustive mode — up to 2 extra
+        # engine passes over the same diff, because an LLM review is not
+        # exhaustive in one pass. Each extra is deduped into $RESULT by
+        # exhaustive-merge.mjs.
+        #
+        # The loop stops early on either of two conditions: a fix-first finding is
+        # already in hand (the gate blocks on what we have, so more depth buys
+        # nothing yet), or a pass adds nothing new. So a run makes at most 3 engine
+        # passes. PASSES carries the count into the summary.
+        #   $1 = log label, $2 = prev-tier fact, $3 = prev fix-first fact,
+        #   $4 = extra passes allowed
         run_review() {
           if ! run_pass "$RESULT" "$1" "$2" "$3"; then
             if [ -f "$RUNNER_TEMP/wallclock-timeout" ]; then
@@ -970,26 +966,14 @@ runs:
           done
         }
 
-        # Single review pass per run (gpt-5.5). The cheap->strong cascade was
-        # retired: testing showed the cheap tier added no value online — it fails
-        # closed on large diffs and otherwise just escalates anyway, taxing every
-        # PR with latency for no decision. We inject the strong-tier facts
-        # (prev-tier=strong) so the DSL's `promoted` rule routes gpt-5.5 for every
-        # run, and run exactly one enforced pass (exhaustive extras still allowed
-        # via the 4th arg). PROMOTE/HELD stay false and `cheap_gate` is never
-        # written, so the promotion-label step and the cheap report step no-op and
-        # the Enforce step does a plain single-pass gate. Size-based front routing
-        # (small->cheap, large->strong, decided up front) is a planned later
-        # optimization and is also single-pass, so this shape stays
-        # forward-compatible: the facts and the DSL rule shape are preserved.
-        PROMOTE=false
-        HELD=false
+        # ONE PASS, one tier, one model. The routing FACTS are still injected —
+        # the recipe reads them, and a later size-based policy (decided up front,
+        # still single-pass) can re-diverge on them without touching this file or
+        # the Action version anyone has pinned. Which is why the facts outlived a
+        # change that removed everything else about tiers.
         PASSES=1
-        run_review "review (gpt-5.5)" "strong" "false" true
-        cp "$RESULT" "$RESULT_STRONG"
-        echo "strong_ran=true" >> "$GITHUB_OUTPUT"
-        echo "promote=$PROMOTE" >> "$GITHUB_OUTPUT"
-        echo "held=$HELD" >> "$GITHUB_OUTPUT"
+        run_review "review" "standard" "false" true
+        cp "$RESULT" "$RESULT_FINAL"
         # Engine passes behind the FINAL result (the last tier that ran) —
         # >1 only in exhaustive mode; the summary comment notes it.
         echo "passes=$PASSES" >> "$GITHUB_OUTPUT"
@@ -1015,12 +999,12 @@ runs:
           echo "::endgroup::"
         fi
 
-    # If a dashboard guardrail/firewall blocked the request, the cascade above
+    # If a dashboard guardrail/firewall blocked the request, the review step above
     # failed closed and the normal review comment never runs. Surface the reason
     # on the PR so the block is actionable, not just a red X with a log line.
-    # always() so it posts despite the failed cascade; no-op when no block file.
+    # always() so it posts despite the failed review step; no-op when no block file.
     # The guard condition also keeps a STALE block file from being posted on a
-    # skipped run (the cascade's own cleanup never ran on a skip).
+    # skipped run (the review step's own cleanup never ran on a skip).
     - name: Surface guardrail / firewall block
       if: always() && steps.settings.outputs.decision != 'skip' && steps.guard.outputs.decision != 'skip'
       uses: actions/github-script@v7
@@ -1085,54 +1069,51 @@ runs:
             await github.rest.issues.updateComment({ ...repo, comment_id: existing.id, body });
           }
 
-    - name: Promote tier
-      if: steps.cascade.outputs.promote == 'true'
-      uses: actions/github-script@v7
-      env:
-        PR_NUMBER: ${{ steps.pr.outputs.number }}
-      with:
-        github-token: ${{ inputs.github-token }}
-        script: |
-          const num = Number(process.env.PR_NUMBER);
-          const repo = { owner: context.repo.owner, repo: context.repo.repo };
-          const name = 'orca-review:strong';
-
-          // The documented setup does not create this label, and addLabels only
-          // attaches labels that already exist — so ensure it exists first,
-          // otherwise the very first promotion would fail instead of recording.
-          try {
-            await github.rest.issues.getLabel({ ...repo, name });
-          } catch (e) {
-            if (e.status !== 404) throw e;
-            try {
-              await github.rest.issues.createLabel({
-                ...repo, name, color: '0e8a16',
-                description: 'OrcaCode Review: promoted to the strong model tier',
-              });
-              core.info(`Created repository label ${name}.`);
-            } catch (e2) {
-              // A parallel first promotion may have created it between our
-              // getLabel and createLabel — 422 "already_exists" is fine.
-              if (e2.status !== 422) throw e2;
-              core.info(`Label ${name} was created concurrently — continuing.`);
-            }
-          }
-
-          await github.rest.issues.addLabels({ ...repo, issue_number: num, labels: [name] });
-          core.info(`PR #${num} promoted to review tier 1 (strong model).`);
-
     # What gets POSTED is decoupled from what gets ENFORCED: this step always
     # produces $RESULT_POSTED for the posting step — a straight copy normally,
     # or with P2 comments dropped when quiet mode is on (dashboard settings).
     # The severity gate, the summary counts, and the run reports keep reading
     # the UNfiltered result: quiet mutes timeline noise, never enforcement.
+    # report_on: which severities the workspace wants PUBLISHED (dashboard →
+    # "Report severities"). The Action did not parse the field before, so the
+    # setting was offered and then silently ignored here.
+    #
+    # FIRST IN THE DISPLAY CHAIN, before quiet, because quiet's question is "is
+    # there anything left to say" and after a narrowed report_on there can be
+    # nothing left to say while the raw result is full of findings.
+    #
+    # The gate, the summary counts and the run report keep reading $RESULT — the
+    # unfiltered file. report_on changes what lands on the PR, never what is
+    # enforced or measured; the union with block_on inside the script is what stops
+    # a display preference from hiding a merge blocker.
+    - name: report_on severity filter
+      if: steps.settings.outputs.decision != 'skip' && steps.guard.outputs.decision != 'skip'
+      shell: bash
+      env:
+        REPORT_FILTER: ${{ github.action_path }}/scripts/report-filter.mjs
+        REPORT_ON: ${{ steps.settings.outputs.report_on }}
+        BLOCK_ON: ${{ steps.settings.outputs.block_on }}
+        RESULT: ${{ runner.temp }}/result.json
+        RESULT_REPORTED: ${{ runner.temp }}/result-reported.json
+      run: |
+        # --show only when there IS a value: an absent flag means "no setting to
+        # apply" and the script passes everything through, while an empty one
+        # legitimately means "only what blocks". Collapsing the two would hide
+        # findings whenever the settings fetch came back thin.
+        if [ -n "$REPORT_ON" ]; then
+          node "$REPORT_FILTER" "$RESULT"             --show "$REPORT_ON" --block-on "$BLOCK_ON" --out "$RESULT_REPORTED"
+        else
+          node "$REPORT_FILTER" "$RESULT" --out "$RESULT_REPORTED"
+        fi
+
     - name: Quiet mode filter
       if: steps.settings.outputs.decision != 'skip' && steps.guard.outputs.decision != 'skip'
       shell: bash
       env:
         QUIET: ${{ steps.settings.outputs.quiet }}
         QUIET_FILTER: ${{ github.action_path }}/scripts/quiet-filter.mjs
-        RESULT: ${{ runner.temp }}/result.json
+        # The report_on-filtered copy, not the raw result — see the step above.
+        RESULT: ${{ runner.temp }}/result-reported.json
         RESULT_POSTED: ${{ runner.temp }}/result-posted.json
       run: |
         if [ "$QUIET" = "true" ]; then
@@ -1278,12 +1259,9 @@ runs:
         INJECT_SCRIPT: ${{ github.action_path }}/scripts/inject-summary.mjs
         GATE: ${{ github.action_path }}/scripts/gate.mjs
         BLOCK_ON: ${{ steps.settings.outputs.block_on }}
-        # Fix-first set — the ❌ count is taken over THIS (not block-on) on a held run.
         FIX_FIRST: ${{ steps.settings.outputs.fix_first }}
-        HELD: ${{ steps.cascade.outputs.held }}
-        STRONG_RAN: ${{ steps.cascade.outputs.strong_ran }}
         QUIET: ${{ steps.settings.outputs.quiet }}
-        PASSES: ${{ steps.cascade.outputs.passes }}
+        PASSES: ${{ steps.review.outputs.passes }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -1332,29 +1310,21 @@ runs:
             }
           }
 
-          // Mirror the enforce step's verdict: held blocks; otherwise gate.mjs
-          // on the final result (exit 0 = a BLOCK_ON severity is present).
-          let blocked = process.env.HELD === 'true';
-          if (!blocked) {
-            try {
-              execFileSync('node', [process.env.GATE, process.env.RESULT, '--has', process.env.BLOCK_ON], { stdio: 'pipe' });
-              blocked = true;
-            } catch { blocked = false; }
-          }
-          const tier = process.env.STRONG_RAN === 'true' ? 'strong' : 'cheap';
-          args.push('--tier', tier, '--push', String(push), '--gate', blocked ? 'blocked' : 'pass');
+          // Mirror the enforce step's verdict: gate.mjs on the final result
+          // (exit 0 = a BLOCK_ON severity is present).
+          let blocked;
+          try {
+            execFileSync('node', [process.env.GATE, process.env.RESULT, '--has', process.env.BLOCK_ON], { stdio: 'pipe' });
+            blocked = true;
+          } catch { blocked = false; }
+          // One tier, one name. This used to report `strong`, from when a cheap
+          // pass could escalate to a strong one; with a single pass the label was
+          // a leftover that made per-tier figures meaningless.
+          args.push('--tier', 'standard', '--push', String(push), '--gate', blocked ? 'blocked' : 'pass');
           // The ❌ line counts findings against the EFFECTIVE block-on set
           // (dashboard/input precedence already applied) — an empty string is
           // a deliberate "block on nothing" and passes through as-is.
           args.push('--block-on', process.env.BLOCK_ON ?? 'P0,P1');
-          // Held run (cheap tier withheld escalation on fix-first findings): the
-          // ❌ count must reflect the FIX-FIRST set, not block-on — block-on may
-          // not include those severities (a repo can even set block_on=''), and
-          // counting over it would render "❌ 0 findings block merge" next to the
-          // held tier line. --held switches the count to fix-first.
-          if (process.env.HELD === 'true') {
-            args.push('--held', '--fix-first', process.env.FIX_FIRST ?? 'P0,P1');
-          }
           // Mode notes: exhaustive pass count (renders only when > 1) and the
           // quiet-mode explainer next to the true counts.
           args.push('--passes', process.env.PASSES || '1');
@@ -1375,15 +1345,10 @@ runs:
         # Effective values after the settings/input precedence rule.
         BLOCK_ON: ${{ steps.settings.outputs.block_on }}
         FIX_FIRST: ${{ steps.settings.outputs.fix_first }}
-        HELD: ${{ steps.cascade.outputs.held }}
         GATE: ${{ github.action_path }}/scripts/gate.mjs
         # ALWAYS the unfiltered result — quiet mode never weakens the gate.
         RESULT: ${{ runner.temp }}/result.json
       run: |
-        if [ "$HELD" = "true" ]; then
-          echo "::error::$BRAND: cheap tier found $FIX_FIRST finding(s) to fix before the strong-tier review runs — blocking."
-          exit 1
-        fi
         if node "$GATE" "$RESULT" --has "$BLOCK_ON"; then
           echo "::error::$BRAND: blocking — found $BLOCK_ON severity finding(s)."
           exit 1
@@ -1395,34 +1360,13 @@ runs:
     # reporting"). One step per tier that ran, AFTER the gate: always() because
     # a blocked gate fails the job above, and blocked runs must report too.
     # report.mjs itself exits 0 on any error, so these steps can't fail the job.
-    - name: Report run (cheap tier)
-      # `cheap_gate` doubles as "the cheap tier ran to a gate decision".
-      if: always() && inputs.report == 'true' && steps.cascade.outputs.cheap_gate != ''
-      shell: bash
-      env:
-        REPORT: ${{ github.action_path }}/scripts/report.mjs
-        RESULT_CHEAP: ${{ runner.temp }}/result-cheap.json
-        REPO: ${{ github.repository }}
-        PR_NUMBER: ${{ steps.pr.outputs.number }}
-        HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
-        CHEAP_GATE: ${{ steps.cascade.outputs.cheap_gate }}
-        ORCAROUTER_URL: ${{ inputs.orcarouter-url }}
-        ORCAROUTER_API_KEY: ${{ inputs.orcarouter-api-key }}
-        ENGINE_VERSION: ${{ inputs.engine-version }}
-      run: |
-        node "$REPORT" "$RESULT_CHEAP" \
-          --repo "$REPO" --pr "$PR_NUMBER" --sha "$HEAD_SHA" \
-          --tier cheap --gate "$CHEAP_GATE" \
-          --url "$ORCAROUTER_URL" \
-          --engine-version "$ENGINE_VERSION"
-
-    - name: Report run (strong tier)
-      if: always() && inputs.report == 'true' && steps.cascade.outputs.strong_ran == 'true'
+    - name: Report run
+      if: always() && inputs.report == 'true' && steps.settings.outputs.decision != 'skip' && steps.guard.outputs.decision != 'skip'
       shell: bash
       env:
         REPORT: ${{ github.action_path }}/scripts/report.mjs
         GATE: ${{ github.action_path }}/scripts/gate.mjs
-        RESULT_STRONG: ${{ runner.temp }}/result-strong.json
+        RESULT_FINAL: ${{ runner.temp }}/result-final.json
         BLOCK_ON: ${{ steps.settings.outputs.block_on }}
         REPO: ${{ github.repository }}
         PR_NUMBER: ${{ steps.pr.outputs.number }}
@@ -1431,13 +1375,13 @@ runs:
         ORCAROUTER_API_KEY: ${{ inputs.orcarouter-api-key }}
         ENGINE_VERSION: ${{ inputs.engine-version }}
       run: |
-        # The strong tier's verdict re-uses gate.mjs on its snapshot
+        # The verdict re-uses gate.mjs on the snapshot
         # (exit 0 = a BLOCK_ON severity is present = blocked).
         GATE_RESULT=pass
-        if node "$GATE" "$RESULT_STRONG" --has "$BLOCK_ON"; then GATE_RESULT=blocked; fi
-        node "$REPORT" "$RESULT_STRONG" \
+        if node "$GATE" "$RESULT_FINAL" --has "$BLOCK_ON"; then GATE_RESULT=blocked; fi
+        node "$REPORT" "$RESULT_FINAL" \
           --repo "$REPO" --pr "$PR_NUMBER" --sha "$HEAD_SHA" \
-          --tier strong --gate "$GATE_RESULT" \
+          --tier standard --gate "$GATE_RESULT" \
           --url "$ORCAROUTER_URL" \
           --engine-version "$ENGINE_VERSION"
 
@@ -1451,7 +1395,7 @@ runs:
         # settings come from env vars), and deleting it would corrupt the OCR
         # state of other jobs/users on the same runner.
         rm -f "$RUNNER_TEMP/result.json" "$RUNNER_TEMP/review.log" \
-          "$RUNNER_TEMP/result-cheap.json" "$RUNNER_TEMP/result-strong.json" \
+          "$RUNNER_TEMP/result-final.json" "$RUNNER_TEMP/result-reported.json" \
           "$RUNNER_TEMP/result-posted.json" "$RUNNER_TEMP/result-extra.json" \
           "$RUNNER_TEMP/result-merged.json" \
           "$RUNNER_TEMP/cr-settings.json" "$RUNNER_TEMP/cr-rubric.md" \

--- a/recipes/_verify-headers.dsl.yaml
+++ b/recipes/_verify-headers.dsl.yaml
@@ -3,19 +3,19 @@
 # Purpose: confirm the gateway surfaces arbitrary Action-injected `x-cr-*`
 # headers into the routing-DSL `headers[...]` CEL env. This is the linchpin of
 # the whole design (the proxy shim stamps facts as headers; the DSL routes on
-# them). If this recipe routes to the "strong" model only when the header is
+# them). If this recipe routes to the second model only when the header is
 # present, headers reach the DSL and we can proceed with the real recipe.
 #
 # How to test: set OCR_LLM_URL through the proxy shim so it stamps
-#   x-cr-prev-tier: strong
-# then run one review and confirm GLM (not DeepSeek) answered. Flip the header
-# to `cheap`/absent and confirm DeepSeek answers.
+#   x-cr-prev-tier: standard
+# then run one review and confirm GLM (not DeepSeek) answered. Remove the header
+# and confirm DeepSeek answers.
 
 version: 1
 
 rules:
   - id: header-probe
-    when: 'headers["x-cr-prev-tier"] == "strong"'
+    when: 'headers["x-cr-prev-tier"] == "standard"'
     use: { model: "z-ai/glm-5.1" }
 
 default:

--- a/recipes/code-review.dsl.yaml
+++ b/recipes/code-review.dsl.yaml
@@ -10,16 +10,17 @@
 # re-paste the block below. After upgrading the Action, re-paste this into the
 # router DSL to actually pick up the single-tier gpt-5.5 policy.
 #
-# Facts injected by the Action (via the in-job proxy shim):
-#   x-cr-prev-tier : none | cheap | strong   (tier used on the previous pass)
-#   x-cr-prev-p0p1 : true | false            (did the previous pass find a P0/P1)
+# Facts injected by the Action on every request (via the in-job proxy shim):
+#   x-cr-prev-tier : standard        (the tier recorded for this run)
+#   x-cr-prev-p0p1 : true | false    (did the previous pass find a P0/P1)
+#
+# x-cr-prev-tier has ONE value now. It used to be none | cheap | strong, back
+# when a cheap pass could escalate to a strong one; a rule you wrote against
+# `cheap` or `strong` will never match again and will fall through to the
+# default. It is still sent because it still says what the run was recorded as.
 #
 # ONE DEFAULT, because one model reviews every run. Add rules above it when you
 # want more than that — the facts to branch on are already arriving.
-#
-# Facts injected on every request:
-#   x-cr-prev-tier : the tier recorded for this run
-#   x-cr-prev-p0p1 : true | false   (did the previous pass find a P0/P1)
 #
 # Nothing reads them today. They are sent anyway so that a policy which wants
 # them — routing small diffs to a cheaper model, say, decided up front and still

--- a/recipes/code-review.dsl.yaml
+++ b/recipes/code-review.dsl.yaml
@@ -14,32 +14,23 @@
 #   x-cr-prev-tier : none | cheap | strong   (tier used on the previous pass)
 #   x-cr-prev-p0p1 : true | false            (did the previous pass find a P0/P1)
 #
-# Single-tier policy: testing showed the cheap->strong cascade added no value
-# online (cheap fails closed on large diffs, otherwise just escalates anyway), so
-# every branch now routes gpt-5.5 — the validated quality bar. The facts are
-# still injected and the rule shape is preserved so a future size-based
-# front-routing policy can re-diverge these branches without an Action change.
+# ONE DEFAULT, because one model reviews every run. Add rules above it when you
+# want more than that — the facts to branch on are already arriving.
 #
-# The `model` in each `use:` below is FREELY CHOOSABLE — swap in any model your
-# OrcaRouter workspace can reach (e.g. openai/gpt-5.5, anthropic/claude-opus-4-8,
-# z-ai/glm-5.1, deepseek/deepseek-v4-pro). gpt-5.5 is our validated default; to
-# re-diverge into a real cost cascade, just give different branches different
-# models (e.g. a cheap model on `holding`, a strong one on `promoted`/`escalate`).
+# Facts injected on every request:
+#   x-cr-prev-tier : the tier recorded for this run
+#   x-cr-prev-p0p1 : true | false   (did the previous pass find a P0/P1)
+#
+# Nothing reads them today. They are sent anyway so that a policy which wants
+# them — routing small diffs to a cheaper model, say, decided up front and still
+# one pass — is an edit to this file in your own workspace rather than a wait for
+# an Action release.
+#
+# THE MODEL IS FREELY CHOOSABLE. Swap in anything your OrcaRouter workspace can
+# reach (openai/gpt-5.5, anthropic/claude-opus-4-8, z-ai/glm-5.1,
+# deepseek/deepseek-v4-pro). gpt-5.5 is our validated default.
 
 version: 1
-
-rules:
-  - id: promoted
-    when: 'headers["x-cr-prev-tier"] == "strong"'
-    use: { model: "openai/gpt-5.5" }
-
-  - id: holding
-    when: 'headers["x-cr-prev-tier"] == "cheap" && headers["x-cr-prev-p0p1"] == "true"'
-    use: { model: "openai/gpt-5.5" }
-
-  - id: escalate
-    when: 'headers["x-cr-prev-tier"] == "cheap" && headers["x-cr-prev-p0p1"] == "false"'
-    use: { model: "openai/gpt-5.5" }
 
 default:
   model: "openai/gpt-5.5"

--- a/scripts/check-result.mjs
+++ b/scripts/check-result.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Availability check for the OrcaCode Review cascade.
+// Availability check for the OrcaCode Review action.
 //
 //   node check-result.mjs <result.json> <exit-code>
 //     exit 0 -> the engine produced a complete, usable review

--- a/scripts/diff-guard.mjs
+++ b/scripts/diff-guard.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Oversized-diff guard for the OrcaCode Review cascade.
+// Oversized-diff guard for the OrcaCode Review action.
 //
 // Reviewing a huge diff is noise: the model truncates context, files get
 // skipped, and the severity signal collapses — better to skip loudly and let

--- a/scripts/exhaustive-merge.mjs
+++ b/scripts/exhaustive-merge.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Exhaustive-mode merge for the OrcaCode Review cascade.
+// Exhaustive-mode merge for the OrcaCode Review action.
 //
 //   node exhaustive-merge.mjs --base <a.json> --new <b.json> --out <merged.json>
 //

--- a/scripts/exhaustive-merge.test.mjs
+++ b/scripts/exhaustive-merge.test.mjs
@@ -169,7 +169,7 @@ describe("robustness", () => {
 });
 
 // The exhaustive loop lives in action.yml's `run_review()` bash function, which
-// drives up to two EXTRA engine passes on the strong tier. Extra depth is
+// drives up to two EXTRA engine passes. Extra depth is
 // best-effort — a benign tooling/merge failure must warn+break and keep the
 // findings already in hand (round-2's guarantee) — but a guardrail/firewall
 // POLICY BLOCK on an extra pass is FATAL: OrcaRouter stopped the request before
@@ -223,7 +223,7 @@ node() {
 `;
     const script =
       `set -eo pipefail\n${extractRunReview()}\n${stubs}\n` +
-      `run_review "strong (escalation)" "cheap" "false" true\n` +
+      `run_review "review" "standard" "false" true\n` +
       `echo "SURVIVED passes=$PASSES"\n`;
     const r = spawnSync("bash", ["-c", script], {
       encoding: "utf8",

--- a/scripts/fact-proxy.mjs
+++ b/scripts/fact-proxy.mjs
@@ -1,20 +1,21 @@
 #!/usr/bin/env node
-// In-job fact-injecting proxy for the OrcaCode Review cascade.
+// In-job fact-injecting proxy for the OrcaCode Review action.
 //
 // OCR can only send the auth header (x-api-key / authorization) — it has no way
 // to attach custom headers. But the routing DSL routes on `headers[...]`. This
 // tiny loopback proxy bridges the gap: OCR talks to it (OCR_LLM_URL points
-// here), it stamps the cascade's raw-fact headers, and forwards everything —
+// here), it stamps the raw-fact headers, and forwards everything —
 // including SSE streams — to the real OrcaRouter endpoint.
 //
 // It is ephemeral: bound to 127.0.0.1 on an OS-assigned port, lives only for
 // the duration of one Actions job, and dies with it. Nothing is deployed.
 //
-// The facts are re-read from CR_FACTS_FILE on EVERY request, so the driver can
-// flip them between the cheap pass and the in-run strong escalation without
-// restarting the proxy. The file is a flat JSON object of header->value; an
-// absent/empty/unparseable file stamps nothing (the DSL falls through to its
-// default, i.e. the cheap tier).
+// The facts are re-read from CR_FACTS_FILE on EVERY request rather than captured
+// at startup, so the driver can change them mid-job without restarting the proxy.
+// The file is a flat JSON object of header->value; an absent, empty or
+// unparseable file stamps nothing, and the DSL then falls through to its default
+// — which is why a broken facts file degrades to "the default model reviewed it"
+// instead of failing the run.
 //
 // Retry: transient upstream failures are retried up to 3 more attempts with
 // 1s/2s/4s backoff; a numeric Retry-After header (seconds) wins, capped at

--- a/scripts/fact-proxy.test.mjs
+++ b/scripts/fact-proxy.test.mjs
@@ -1075,7 +1075,7 @@ describe("action.yml wiring (guardrail / firewall block comment)", () => {
 
   test("a resumed clean review retires the stale block comment", () => {
     const yml = actionYml();
-    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Enforce severity gate");
+    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Detach the retired tier label");
     assert.match(summary, /orca-code-review-block/, "the summary step must delete a stale block comment once reviews resume");
   });
 });

--- a/scripts/fact-proxy.test.mjs
+++ b/scripts/fact-proxy.test.mjs
@@ -1,5 +1,5 @@
 // Contract tests for fact-proxy.mjs — the in-job loopback proxy that stamps
-// cascade facts onto OCR's requests and forwards them to the OrcaRouter
+// routing facts onto OCR's requests and forwards them to the OrcaRouter
 // gateway.
 //
 // Retry contract (A3): 429/502/503/504 is retried up to 3 more attempts with
@@ -1047,11 +1047,26 @@ describe("rate limiting (CR_MAX_RPM)", () => {
 describe("action.yml wiring (guardrail / firewall block comment)", () => {
   const actionYml = () => readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "action.yml"), "utf8");
 
+  // sliceStep, because the previous version passed `yml.indexOf(<a step that has
+  // since been deleted>)` as the end bound. indexOf returns -1, slice(start, -1)
+  // runs to the end of the file, and the three assertions below then matched
+  // anything anywhere after the step — they would have kept passing with the
+  // marker gone. A boundary that no longer exists has to fail loudly rather than
+  // widen silently.
+  const sliceStep = (yml, from, to) => {
+    const a = yml.indexOf(from);
+    const b = yml.indexOf(to);
+    assert.ok(a >= 0, `step not found: ${from}`);
+    assert.ok(b > a, `boundary step not found after ${from}: ${to}`);
+    return yml.slice(a, b);
+  };
+
   test("the block comment is upserted by its own marker (not a new comment on every push)", () => {
     const yml = actionYml();
-    const step = yml.slice(
-      yml.indexOf("- name: Surface guardrail / firewall block"),
-      yml.indexOf("- name: Promote tier"),
+    const step = sliceStep(
+      yml,
+      "- name: Surface guardrail / firewall block",
+      "- name: report_on severity filter",
     );
     assert.match(step, /<!-- orca-code-review-block -->/, "the block comment needs an upsert marker");
     assert.match(step, /listComments/, "it must look for an existing block comment");
@@ -1060,7 +1075,7 @@ describe("action.yml wiring (guardrail / firewall block comment)", () => {
 
   test("a resumed clean review retires the stale block comment", () => {
     const yml = actionYml();
-    const summary = yml.slice(yml.indexOf("- name: Summary (PR description)"), yml.indexOf("- name: Enforce severity gate"));
+    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Enforce severity gate");
     assert.match(summary, /orca-code-review-block/, "the summary step must delete a stale block comment once reviews resume");
   });
 });

--- a/scripts/fact-proxy.test.mjs
+++ b/scripts/fact-proxy.test.mjs
@@ -1075,7 +1075,7 @@ describe("action.yml wiring (guardrail / firewall block comment)", () => {
 
   test("a resumed clean review retires the stale block comment", () => {
     const yml = actionYml();
-    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Detach the retired tier label");
+    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Enforce severity gate");
     assert.match(summary, /orca-code-review-block/, "the summary step must delete a stale block comment once reviews resume");
   });
 });

--- a/scripts/gate.mjs
+++ b/scripts/gate.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Severity gate for the OrcaCode Review cascade.
+// Severity gate for the OrcaCode Review action.
 //
 // Reads an `ocr review --format json` result file, extracts the [P0]/[P1]/[P2]/[P3]
 // tag the model prefixes onto each comment, and answers one yes/no question:

--- a/scripts/gate.test.mjs
+++ b/scripts/gate.test.mjs
@@ -1,12 +1,14 @@
-// Contract tests for gate.mjs — the cascade's decision primitive.
+// Contract tests for gate.mjs — the decision primitive behind the merge gate and
+// the exhaustive loop's early stop.
 //
-// The stateful cascade (action.yml) drives both the promotion choice and the
-// merge gate purely off this script's exit code:
-//   - promotion: `if gate --has $FIX_FIRST` is TRUE  -> stay on the cheap tier
-//                                             FALSE -> promote PR to strong tier
-//   - merge gate: `if gate --has $BLOCK_ON`  is TRUE  -> fail the check (block)
-// So locking down these exit codes locks down the review-routing logic. Run
-// these before changing anything about cascade/severity behavior.
+// Two callers depend on its exit code:
+//   - the merge gate: `gate --has $BLOCK_ON` TRUE  -> fail the check
+//                                            FALSE -> pass
+//   - the exhaustive loop: `gate --has $FIX_FIRST` TRUE -> stop adding passes,
+//     because the gate already blocks on what is in hand
+//
+// So the exit code IS the policy, and reading it backwards inverts both. Run
+// these before changing anything about severity behaviour.
 
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
@@ -40,27 +42,27 @@ function gate(contents, has) {
   }
 }
 
-const FIX_FIRST = "P0,P1"; // severities that hold the PR on the cheap tier
+const FIX_FIRST = "P0,P1"; // severities the exhaustive loop stops on
 const BLOCK_ON = "P0"; // severities that block the merge
 
-describe("promotion decision (--has FIX_FIRST)", () => {
-  test("P0 present -> match (stay on cheap tier, fix first)", () => {
+describe("exhaustive early-stop decision (--has FIX_FIRST)", () => {
+  test("P0 present -> match (stop adding passes; fix that first)", () => {
     assert.equal(gate(["[P0] sql injection", "[P2] use const"], FIX_FIRST), 0);
   });
 
-  test("P1 present -> match (stay on cheap tier)", () => {
+  test("P1 present -> match (stop adding passes)", () => {
     assert.equal(gate(["[P1] possible null deref"], FIX_FIRST), 0);
   });
 
-  test("P2-only -> no match (promote PR to strong tier)", () => {
+  test("P2-only -> no match (extra depth may still find something)", () => {
     assert.equal(gate(["[P2] use const", "[P2] dead code"], FIX_FIRST), 1);
   });
 
-  test("clean (no findings) -> no match (promote PR to strong tier)", () => {
+  test("clean (no findings) -> no match (extra depth may still find something)", () => {
     assert.equal(gate([], FIX_FIRST), 1);
   });
 
-  test("untagged finding -> treated as P1 (stay on cheap tier, fail-safe)", () => {
+  test("untagged finding -> treated as P1 (stop, fail-safe)", () => {
     assert.equal(gate(["no severity tag, but a real bug"], FIX_FIRST), 0);
   });
 });

--- a/scripts/quiet-filter.mjs
+++ b/scripts/quiet-filter.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Quiet-mode severity filter for the OrcaCode Review cascade.
+// Quiet-mode severity filter for the OrcaCode Review action.
 //
 //   node quiet-filter.mjs <result.json> --drop P2 --out <filtered.json>
 //

--- a/scripts/report-filter.mjs
+++ b/scripts/report-filter.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// report_on severity filter.
+//
+//   node report-filter.mjs <result.json> --show P0,P1 --block-on P0,P1 --out <filtered.json>
+//
+// WHY THIS EXISTS. `report_on` is a per-workspace/per-repo setting ("Report
+// severities" in the dashboard) that decides which severities are PUBLISHED. The
+// Action did not apply it — it did not even parse the field — so a workspace
+// that narrowed the setting had it silently ignored here. A knob that is offered
+// and then not honoured is worse than one that does not exist.
+//
+// SHOW = report_on UNION block_on, and the union is the load-bearing part. A
+// severity the workspace configured as merge-blocking must never be hidden by a
+// display preference: "show me less" would otherwise quietly disable the gate
+// the same workspace asked for. The gate itself keeps reading the UNfiltered
+// result, so this cannot change what is enforced — only what is shown — but a
+// blocked merge with no visible reason is its own defect.
+//
+// AND NOTHING ELSE MOVES. Not the severity tally, not the gate, not the clean
+// marker, not the control-plane run report: those describe what the review
+// FOUND. action.yml feeds the filtered file to the posting step only, exactly
+// as it does for quiet mode.
+//
+// NO --show FLAG AT ALL means no filtering, which is not the same as an empty
+// value. An empty --show is a legitimate configuration meaning "only what
+// blocks" (the union leaves block_on behind); an absent flag means the driver
+// had no setting to apply — a failed settings fetch, say — and display must
+// fail OPEN in that case. Hiding findings because a fetch timed out would be
+// the wrong direction on both counts.
+//
+// Severity comes from the shared severity.mjs (leading-tag-only parsing plus
+// the untagged->P1 fail-safe), the same reader the gate, the quiet filter and
+// the run report use. A third notion of severity in this repository is how the
+// gate and the display would come to disagree about the same finding.
+//
+// Failure behavior mirrors quiet-filter.mjs: a missing or unparseable input
+// writes an empty engine-shaped result and exits 0, because that is what the
+// posting step's own try/catch would do with the raw file. Bad USAGE exits 2 —
+// that is a wiring bug in action.yml and has to be loud.
+
+import fs from "node:fs";
+import { SEVERITIES, severityOf } from "./severity.mjs";
+
+const usage = () => {
+  console.error(
+    "usage: node report-filter.mjs <result.json> [--show P0,P1] [--block-on P0,P1] --out <filtered.json>",
+  );
+  process.exit(2);
+};
+
+const [file, ...rest] = process.argv.slice(2);
+if (!file) usage();
+
+const opts = { show: null, blockOn: "P0,P1", out: null };
+for (let i = 0; i < rest.length; i += 1) {
+  const flag = rest[i];
+  // A flag's VALUE is not another flag: catching that here turns a mangled
+  // action.yml expansion (an empty `${{ ... }}` swallowing the next argument)
+  // into a usage error instead of a silently wrong severity set.
+  const value = rest[i + 1];
+  if (flag === "--out") {
+    if (value === undefined || value.startsWith("--")) usage();
+    opts.out = value;
+    i += 1;
+  } else if (flag === "--show") {
+    if (value === undefined || value.startsWith("--")) usage();
+    opts.show = value;
+    i += 1;
+  } else if (flag === "--block-on") {
+    if (value === undefined || value.startsWith("--")) usage();
+    opts.blockOn = value;
+    i += 1;
+  } else {
+    usage();
+  }
+}
+if (!opts.out) usage();
+
+const parseSet = (raw) => {
+  const set = new Set();
+  for (const piece of String(raw).split(",")) {
+    const sev = piece.trim().toUpperCase();
+    if (!sev) continue;
+    // An unknown severity is a wiring bug, not a finding to drop. Loud, because
+    // the alternative is a keep-set quietly missing a level nobody notices
+    // until findings stop appearing.
+    if (!SEVERITIES.includes(sev)) {
+      console.error(`report-filter: unknown severity ${JSON.stringify(sev)}`);
+      process.exit(2);
+    }
+    set.add(sev);
+  }
+  return set;
+};
+
+let parsed;
+try {
+  parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+} catch {
+  fs.writeFileSync(opts.out, JSON.stringify({ comments: [] }));
+  process.stdout.write(`${JSON.stringify({ shown: 0, withheld: 0 })}\n`);
+  process.exit(0);
+}
+
+const comments = Array.isArray(parsed?.comments) ? parsed.comments : [];
+
+if (opts.show === null) {
+  // Pass-through, byte-for-byte in shape: no setting was supplied, so there is
+  // nothing to apply and nothing to report as withheld.
+  fs.writeFileSync(opts.out, JSON.stringify({ ...parsed, comments }));
+  process.stdout.write(`${JSON.stringify({ shown: comments.length, withheld: 0 })}\n`);
+  process.exit(0);
+}
+
+const keep = parseSet(opts.show);
+for (const sev of parseSet(opts.blockOn)) keep.add(sev);
+
+const shown = comments.filter((c) => keep.has(severityOf(c)));
+const withheld = comments.length - shown.length;
+
+fs.writeFileSync(opts.out, JSON.stringify({ ...parsed, comments: shown }));
+if (withheld > 0) {
+  console.error(
+    `report-filter: withheld ${withheld} of ${comments.length} finding(s) — shown ${[...keep].sort().join(",")}`,
+  );
+}
+process.stdout.write(`${JSON.stringify({ shown: shown.length, withheld })}\n`);

--- a/scripts/report-filter.test.mjs
+++ b/scripts/report-filter.test.mjs
@@ -1,0 +1,148 @@
+// Contract tests for report-filter.mjs — the publish-side severity filter.
+//
+// The seam worth pinning is three-valued, and the middle value is the one that
+// already went wrong once in action.yml: NO --show means "no setting, pass
+// everything through", an EMPTY --show means "publish only what blocks", and a
+// populated --show means that set UNION block_on. Collapsing the first two
+// published every severity for a workspace that had asked for the opposite.
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { after, before, describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+const SCRIPTS = dirname(fileURLToPath(import.meta.url));
+const FILTER = join(SCRIPTS, "report-filter.mjs");
+let dir;
+
+before(() => {
+  dir = mkdtempSync(join(tmpdir(), "report-filter-test-"));
+});
+after(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const FIXTURE = ["[P0] sqli", "[P1] null deref", "[P2] conditional bug", "[P3] naming", "untagged"];
+
+let n = 0;
+function run(contents, args, extra = {}) {
+  n += 1;
+  const input = join(dir, `in-${n}.json`);
+  const out = join(dir, `out-${n}.json`);
+  if (contents !== null) {
+    writeFileSync(input, JSON.stringify({ engine: "ocr", comments: contents.map((content) => ({ content })) }));
+  }
+  const r = spawnSync("node", [FILTER, extra.file ?? input, ...args, "--out", out], { encoding: "utf8" });
+  let result = null;
+  try {
+    result = JSON.parse(readFileSync(out, "utf8"));
+  } catch {
+    /* the script may legitimately not have written it (usage errors) */
+  }
+  return { ...r, result, kept: (result?.comments ?? []).map((c) => c.content) };
+}
+
+describe("the three states of --show", () => {
+  test("NO --show: pass-through, and the envelope survives", () => {
+    const r = run(FIXTURE, ["--block-on", "P0"]);
+    assert.equal(r.status, 0, r.stderr);
+    assert.deepEqual(r.kept, FIXTURE, "an absent setting must not drop anything");
+    assert.equal(r.result.engine, "ocr", "sibling keys must be carried through");
+    assert.deepEqual(JSON.parse(r.stdout), { shown: 5, withheld: 0 });
+  });
+
+  test("EMPTY --show: only what blocks", () => {
+    const r = run(FIXTURE, ["--show", "", "--block-on", "P0,P1"]);
+    assert.equal(r.status, 0, r.stderr);
+    // "untagged" is P1 by the shared fail-safe, so it blocks and therefore shows.
+    assert.deepEqual(r.kept, ["[P0] sqli", "[P1] null deref", "untagged"]);
+    assert.deepEqual(JSON.parse(r.stdout), { shown: 3, withheld: 2 });
+  });
+
+  test("populated --show: the union with block-on, never the difference", () => {
+    // The workspace asked to see P3 only, and blocks on P0. Hiding the P0 would
+    // fail the merge with nothing on the diff explaining why.
+    const r = run(FIXTURE, ["--show", "P3", "--block-on", "P0"]);
+    assert.equal(r.status, 0, r.stderr);
+    assert.deepEqual(r.kept, ["[P0] sqli", "[P3] naming"]);
+  });
+
+  test("a block-on severity cannot be withheld even when show excludes all of it", () => {
+    const r = run(["[P0] one", "[P1] two"], ["--show", "P2,P3", "--block-on", "P0,P1"]);
+    assert.equal(r.status, 0, r.stderr);
+    assert.deepEqual(r.kept, ["[P0] one", "[P1] two"]);
+    assert.deepEqual(JSON.parse(r.stdout), { shown: 2, withheld: 0 });
+  });
+});
+
+describe("severity parsing is the shared one", () => {
+  test("an untagged finding is P1, and a tag is case-insensitive", () => {
+    const r = run(["untagged", "[p2] lower"], ["--show", "P1", "--block-on", ""]);
+    assert.equal(r.status, 0, r.stderr);
+    assert.deepEqual(r.kept, ["untagged"], "untagged -> P1 kept; [p2] parsed as P2 and dropped");
+  });
+
+  test("a tag that is not leading does not count", () => {
+    const r = run(["see [P0] in the example above"], ["--show", "P0", "--block-on", ""]);
+    assert.equal(r.status, 0, r.stderr);
+    assert.deepEqual(r.kept, [], "prose mentioning [P0] is an untagged P1, not a P0");
+  });
+});
+
+describe("failure behavior", () => {
+  test("missing input -> empty result, exit 0 (display must not fail the job)", () => {
+    const r = run(null, ["--show", "P0"], { file: join(dir, "nope.json") });
+    assert.equal(r.status, 0, r.stderr);
+    assert.deepEqual(r.result, { comments: [] });
+    assert.deepEqual(JSON.parse(r.stdout), { shown: 0, withheld: 0 });
+  });
+
+  test("unparseable input -> empty result, exit 0", () => {
+    const input = join(dir, "garbage.json");
+    writeFileSync(input, "{not json");
+    const out = join(dir, "garbage-out.json");
+    const r = spawnSync("node", [FILTER, input, "--show", "P0", "--out", out], { encoding: "utf8" });
+    assert.equal(r.status, 0, r.stderr);
+    assert.deepEqual(JSON.parse(readFileSync(out, "utf8")), { comments: [] });
+  });
+
+  test("an unknown severity is a WIRING bug -> exit 2", () => {
+    const r = run(FIXTURE, ["--show", "P1,P9"]);
+    assert.equal(r.status, 2, "a bad severity set must be loud, not silently narrowed");
+    assert.match(r.stderr, /unknown severity/);
+  });
+
+  test("--show swallowing the next flag -> exit 2, not a wrong severity set", () => {
+    // What an empty `${{ ... }}` expansion looks like from the shell.
+    const r = run(FIXTURE, ["--show", "--block-on", "P0"]);
+    assert.equal(r.status, 2, "a flag is never a value");
+    assert.match(r.stderr, /usage/);
+  });
+
+  test("no --out -> exit 2", () => {
+    const input = join(dir, "no-out.json");
+    writeFileSync(input, JSON.stringify({ comments: [] }));
+    const r = spawnSync("node", [FILTER, input, "--show", "P0"], { encoding: "utf8" });
+    assert.equal(r.status, 2);
+  });
+});
+
+describe("action.yml wiring", () => {
+  test("the filter runs BEFORE quiet, and only posting reads the end of the chain", () => {
+    const yml = readFileSync(join(SCRIPTS, "..", "action.yml"), "utf8");
+    const reportOn = yml.indexOf("- name: report_on severity filter");
+    const quiet = yml.indexOf("- name: Quiet mode filter");
+    const post = yml.indexOf("- name: Post review comments");
+    assert.ok(reportOn > 0 && quiet > reportOn && post > quiet, "report_on -> quiet -> post");
+    // The gate and the run report must not see the filtered copies at all —
+    // covered structurally in settings.test.mjs; here just pin that the two
+    // intermediate files are distinct, so neither stage overwrites the other's
+    // input and the raw result stays raw.
+    for (const f of ["result.json", "result-reported.json", "result-posted.json"]) {
+      assert.ok(yml.includes(f), `${f} must be wired`);
+    }
+  });
+});

--- a/scripts/report.mjs
+++ b/scripts/report.mjs
@@ -2,7 +2,7 @@
 // Best-effort run report to the OrcaRouter control plane.
 //
 //   node report.mjs <result.json> --repo <owner/name> --pr <n> --sha <sha>
-//     --tier cheap|strong --gate pass|blocked --url <orcarouter-url>
+//     --tier standard --gate pass|blocked --url <orcarouter-url>
 //     [--engine-version <v>]
 //   (the API key comes from ORCAROUTER_API_KEY in the env, never a flag)
 //
@@ -47,7 +47,7 @@ async function main() {
   if (!file || !opts.repo || !opts.pr || !opts.sha || !opts.tier || !opts.gate || !opts.url || !opts.key) {
     console.error(
       "report: usage: ORCAROUTER_API_KEY=<key> node report.mjs <result.json> --repo X --pr N --sha S " +
-        "--tier cheap|strong --gate pass|blocked --url U [--engine-version V] " +
+        "--tier standard --gate pass|blocked --url U [--engine-version V] " +
         "(best-effort — exiting 0)",
     );
     return;

--- a/scripts/report.test.mjs
+++ b/scripts/report.test.mjs
@@ -9,7 +9,7 @@
 // STRICTLY best-effort: any failure — bad file, refused connection, HTTP 5xx —
 // logs to stderr and still exits 0 (the child exit status is asserted below);
 // one retry, 5s timeout. The "report: false" disable switch is NOT in this script:
-// it is the `inputs.report == 'true'` guard on the two report steps in
+// it is the `inputs.report == 'true'` guard on the report step in
 // action.yml — the last test pins that guard so it can't be dropped.
 
 import http from "node:http";
@@ -86,7 +86,7 @@ const baseArgs = (file, port, extra = []) => [
   "--repo", "acme/widgets",
   "--pr", "42",
   "--sha", "deadbeef123",
-  "--tier", "cheap",
+  "--tier", "standard",
   "--gate", "blocked",
   "--url", `http://127.0.0.1:${port}/v1/chat/completions`,
   ...extra,
@@ -108,7 +108,7 @@ describe("payload assembly", () => {
         repo: "acme/widgets",
         pr_number: 42, // a NUMBER, not a string
         head_sha: "deadbeef123",
-        tier: "cheap",
+        tier: "standard",
         p0: 1,
         p1: 2, // [P1] + the untagged fail-safe
         p2: 2,
@@ -179,15 +179,22 @@ describe("best-effort (must never fail the job)", () => {
 });
 
 describe("disable switch (report: \"false\")", () => {
-  test("action.yml guards both per-tier report steps on the `report` input", () => {
+  test("action.yml guards the report step on the `report` input", () => {
     // The off switch lives at the STEP level, not in this script: when the
-    // consumer sets `report: "false"`, the steps are skipped entirely and
+    // consumer sets `report: "false"`, the step is skipped entirely and
     // report.mjs is never invoked. Pin the guard so a refactor can't drop it.
+    //
+    // ONE step, where this used to require two — one per tier. The assertion is
+    // written as a count equality rather than a fixed number so it holds whether
+    // there is one invocation or five: every one of them stays behind the switch.
     const actionYml = readFileSync(join(SCRIPTS, "..", "action.yml"), "utf8");
     const guards = actionYml.match(/inputs\.report == 'true'/g) || [];
-    assert.ok(
-      guards.length >= 2,
-      "both report steps (cheap + strong) must carry an `inputs.report == 'true'` if-guard",
+    const invocations = actionYml.match(/node "\$REPORT"/g) || [];
+    assert.ok(guards.length >= 1, "the report step must carry an `inputs.report == 'true'` if-guard");
+    assert.equal(
+      invocations.length,
+      guards.length,
+      "every report.mjs invocation must sit in a step guarded by the `report` input",
     );
   });
 });

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Dashboard settings fetch for the OrcaCode Review cascade.
+// Dashboard settings fetch for the OrcaCode Review action.
 //
 //   node settings.mjs --url <orcarouter-url> --repo owner/name --out <path.json>
 //   (the API key comes from ORCAROUTER_API_KEY in the env, never a flag)
@@ -47,6 +47,16 @@ const DEFAULTS = Object.freeze({
   quiet: false,
   fix_first: "P0,P1",
   block_on: "P0,P1",
+  // EVERY severity, and this is the FAILURE value rather than the product
+  // default. A workspace created after report_on shipped gets P0,P1 written
+  // explicitly by the gateway, while one that predates the setting still
+  // resolves to every severity — so no single value here can match "what this
+  // workspace normally sees".
+  //
+  // So it fails OPEN. An install that normally shows P2/P3 must not lose them
+  // because a settings call timed out; the opposite mistake only shows a reader
+  // more than they asked for, once, in a run that already logged a fetch failure.
+  report_on: "P0,P1,P2,P3",
   rubric: "",
 });
 
@@ -81,7 +91,12 @@ function validateSettings(data) {
   if (TRIGGERS.has(data.trigger)) out.trigger = data.trigger;
   else fallback("trigger", data.trigger);
 
-  for (const field of ["fix_first", "block_on"]) {
+  // report_on rides in this loop because it is the same shape as the other two —
+  // a comma-joined severity subset where "" is a deliberate "none" — but it
+  // answers a different question: fix_first and block_on decide what the review
+  // ENFORCES, report_on only what it SHOWS. A gateway that predates the field
+  // omits it, which lands on the default above and behaves as before.
+  for (const field of ["fix_first", "block_on", "report_on"]) {
     const normalized = normalizeSeverityList(data[field]);
     if (normalized !== null) out[field] = normalized;
     else fallback(field, data[field]);

--- a/scripts/settings.test.mjs
+++ b/scripts/settings.test.mjs
@@ -437,37 +437,19 @@ describe("action.yml wiring (settings, quiet mode)", () => {
     }
   });
 
-  test("the retired-label cleanup can never fail a review", () => {
-    // It is migration cleanup for a label an older version attached, so it must
-    // be strictly weaker than the review it runs beside: swallow the 404 that
-    // means "no such label" (the normal case), and carry continue-on-error so a
-    // permissions or API problem cannot turn a passing review into a red check.
-    // It also has to sit BEFORE the gate — the gate exits non-zero on a blocking
-    // finding, and a blocked PR is exactly the kind that was promoted.
-    const yml = actionYml();
-    const step = sliceStep(yml, "- name: Detach the retired tier label", "- name: Enforce severity gate");
-    assert.match(step, /continue-on-error: true/, "cleanup must not be able to fail the job");
-    assert.match(step, /removeLabel/, "it must detach rather than list-then-detach");
-    assert.match(step, /status !== 404/, "a missing label is the normal case, not an error");
-    assert.ok(
-      yml.indexOf("- name: Detach the retired tier label") < yml.indexOf("- name: Enforce severity gate"),
-      "the cleanup must run before the gate, or a blocked PR never gets cleaned",
-    );
-  });
-
   test("the summary step has no held branch: the ❌ count follows block-on, never fix-first", () => {
     // There is one review per push, so there is no run whose ❌ count should
     // follow fix_first instead of block_on. If a --held branch comes back, the
     // summary and the gate can disagree about what blocks the PR.
     const yml = actionYml();
-    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Detach the retired tier label");
+    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Enforce severity gate");
     assert.doesNotMatch(summary, /--held/, "the summary must not pass --held");
     assert.doesNotMatch(summary, /HELD/, "there is no held state to branch on");
   });
 
   test("the summary step passes the EFFECTIVE block-on set to summary-comment.mjs", () => {
     const yml = actionYml();
-    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Detach the retired tier label");
+    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Enforce severity gate");
     assert.match(summary, /--block-on/, "the ❌ count must follow the configured block-on set, not a hardcoded P0+P1");
     assert.match(summary, /steps\.settings\.outputs\.block_on/, "and it must be the settings-aware effective value");
   });
@@ -498,7 +480,7 @@ describe("action.yml wiring (settings, quiet mode)", () => {
 
   test("a resumed review retires the stale settings-skip and oversized-skip notices", () => {
     const yml = actionYml();
-    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Detach the retired tier label");
+    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Enforce severity gate");
     assert.match(summary, /orca-code-review-disabled/, "the 'auto review off' notice must be cleaned up");
     assert.match(summary, /orca-code-review-skip/, "the 'diff too large' notice must be cleaned up");
     assert.match(summary, /deleteComment/, "cleanup means deleting the stale comment");

--- a/scripts/settings.test.mjs
+++ b/scripts/settings.test.mjs
@@ -437,19 +437,37 @@ describe("action.yml wiring (settings, quiet mode)", () => {
     }
   });
 
+  test("the retired-label cleanup can never fail a review", () => {
+    // It is migration cleanup for a label an older version attached, so it must
+    // be strictly weaker than the review it runs beside: swallow the 404 that
+    // means "no such label" (the normal case), and carry continue-on-error so a
+    // permissions or API problem cannot turn a passing review into a red check.
+    // It also has to sit BEFORE the gate — the gate exits non-zero on a blocking
+    // finding, and a blocked PR is exactly the kind that was promoted.
+    const yml = actionYml();
+    const step = sliceStep(yml, "- name: Detach the retired tier label", "- name: Enforce severity gate");
+    assert.match(step, /continue-on-error: true/, "cleanup must not be able to fail the job");
+    assert.match(step, /removeLabel/, "it must detach rather than list-then-detach");
+    assert.match(step, /status !== 404/, "a missing label is the normal case, not an error");
+    assert.ok(
+      yml.indexOf("- name: Detach the retired tier label") < yml.indexOf("- name: Enforce severity gate"),
+      "the cleanup must run before the gate, or a blocked PR never gets cleaned",
+    );
+  });
+
   test("the summary step has no held branch: the ❌ count follows block-on, never fix-first", () => {
     // There is one review per push, so there is no run whose ❌ count should
     // follow fix_first instead of block_on. If a --held branch comes back, the
     // summary and the gate can disagree about what blocks the PR.
     const yml = actionYml();
-    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Enforce severity gate");
+    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Detach the retired tier label");
     assert.doesNotMatch(summary, /--held/, "the summary must not pass --held");
     assert.doesNotMatch(summary, /HELD/, "there is no held state to branch on");
   });
 
   test("the summary step passes the EFFECTIVE block-on set to summary-comment.mjs", () => {
     const yml = actionYml();
-    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Enforce severity gate");
+    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Detach the retired tier label");
     assert.match(summary, /--block-on/, "the ❌ count must follow the configured block-on set, not a hardcoded P0+P1");
     assert.match(summary, /steps\.settings\.outputs\.block_on/, "and it must be the settings-aware effective value");
   });
@@ -480,7 +498,7 @@ describe("action.yml wiring (settings, quiet mode)", () => {
 
   test("a resumed review retires the stale settings-skip and oversized-skip notices", () => {
     const yml = actionYml();
-    const summary = yml.slice(yml.indexOf("- name: Summary (PR description)"), yml.indexOf("- name: Enforce severity gate"));
+    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Detach the retired tier label");
     assert.match(summary, /orca-code-review-disabled/, "the 'auto review off' notice must be cleaned up");
     assert.match(summary, /orca-code-review-skip/, "the 'diff too large' notice must be cleaned up");
     assert.match(summary, /deleteComment/, "cleanup means deleting the stale comment");

--- a/scripts/settings.test.mjs
+++ b/scripts/settings.test.mjs
@@ -45,6 +45,10 @@ const DEFAULTS = {
   quiet: false,
   fix_first: "P0,P1",
   block_on: "P0,P1",
+  // Fail-open, NOT the product default: this is what the action falls back to
+  // when the dashboard is unreachable, and an outage must never silently
+  // withhold findings. The configured default is narrower and lives server-side.
+  report_on: "P0,P1,P2,P3",
   rubric: "",
 };
 
@@ -104,6 +108,7 @@ describe("settings: happy fetch", () => {
       quiet: true,
       fix_first: "P0",
       block_on: "P0,P1,P2",
+      report_on: "P0,P1",
       rubric: "Custom rubric: tag every comment [P0]/[P1]/[P2].",
     };
     const gw = await startGateway([{ status: 200, body: envelope(data) }]);
@@ -226,6 +231,7 @@ describe("settings: field-wise fallback on invalid values", () => {
           quiet: "yes", // not a bool -> default
           fix_first: "P0,P9", // P9 is not a severity -> default
           block_on: 42, // not a string -> default
+          report_on: "P1,nope", // not all severities -> default
           rubric: 123, // not a string -> default
         }),
       },
@@ -241,6 +247,7 @@ describe("settings: field-wise fallback on invalid values", () => {
         quiet: false,
         fix_first: "P0,P1",
         block_on: "P0,P1",
+        report_on: "P0,P1,P2,P3",
         rubric: "",
       });
       assert.match(r.stderr, /trigger/, "field fallbacks must be noted on stderr");
@@ -377,30 +384,45 @@ describe("action.yml wiring (settings, quiet mode)", () => {
     );
   });
 
-  test("only the POST step reads the quiet-filtered result; gate + BOTH report steps keep the true counts", () => {
+  // sliceStep instead of a bare indexOf pair: a boundary step that has been
+  // renamed or removed makes indexOf return -1, slice(start, -1) run to the end
+  // of the file, and every assertion below match against most of action.yml —
+  // passing for the wrong reason. This suite lost two boundary steps when the
+  // cascade went, so the failure mode is not hypothetical.
+  const sliceStep = (yml, from, to) => {
+    const a = yml.indexOf(from);
+    const b = yml.indexOf(to);
+    assert.ok(a >= 0, `step not found: ${from}`);
+    assert.ok(b > a, `boundary step not found after ${from}: ${to}`);
+    return yml.slice(a, b);
+  };
+
+  test("only the POST step reads the display-filtered result; the gate and the report keep the true counts", () => {
     const yml = actionYml();
-    const post = yml.slice(yml.indexOf("- name: Post review comments"), yml.indexOf("- name: Summary (PR description)"));
-    assert.match(post, /result-posted\.json/, "posting must read the quiet-filtered file");
-    const gate = yml.slice(yml.indexOf("- name: Enforce severity gate"), yml.indexOf("- name: Report run (cheap tier)"));
+    const post = sliceStep(yml, "- name: Post review comments", "- name: Summary (PR description)");
+    assert.match(post, /result-posted\.json/, "posting must read the display-filtered file");
+
+    // The DISPLAY CHAIN is report_on then quiet, and only the posting step reads
+    // its output. Everything that enforces or measures reads the raw result.
+    const reportOn = sliceStep(yml, "- name: report_on severity filter", "- name: Quiet mode filter");
+    assert.match(reportOn, /\/result\.json/, "the report_on filter must read the unfiltered result");
+    const quiet = sliceStep(yml, "- name: Quiet mode filter", "- name: Post review comments");
+    assert.match(quiet, /result-reported\.json/, "quiet must read the report_on-filtered copy, not the raw one");
+
+    const gate = sliceStep(yml, "- name: Enforce severity gate", "- name: Report run");
     assert.match(gate, /\/result\.json/, "the gate must read the unfiltered result");
     assert.doesNotMatch(gate, /result-posted\.json/, "the gate must NOT read the filtered result");
-    // The per-tier report steps read the UNFILTERED tier snapshots (RESULT_CHEAP
-    // / RESULT_STRONG), never the quiet-filtered posted copy — quiet mutes the
-    // timeline, never enforcement or reporting.
-    const cheapReport = yml.slice(yml.indexOf("- name: Report run (cheap tier)"), yml.indexOf("- name: Report run (strong tier)"));
-    assert.match(cheapReport, /result-cheap\.json/, "the cheap report must read the unfiltered cheap snapshot");
-    assert.doesNotMatch(cheapReport, /result-posted\.json/, "the cheap report must NOT read the filtered result");
-    const strongReport = yml.slice(yml.indexOf("- name: Report run (strong tier)"), yml.indexOf("- name: Clean up engine output"));
-    assert.match(strongReport, /result-strong\.json/, "the strong report must read the unfiltered strong snapshot");
-    assert.doesNotMatch(strongReport, /result-posted\.json/, "the strong report must NOT read the filtered result");
+
+    const report = sliceStep(yml, "- name: Report run", "- name: Clean up engine output");
+    assert.match(report, /result-final\.json/, "the report must read the unfiltered snapshot");
+    assert.doesNotMatch(report, /result-posted\.json/, "the report must NOT read the filtered result");
   });
 
-  test("the settings + both report steps take the API key from ORCAROUTER_API_KEY env and pass NO --key flag (argv-leak guard)", () => {
+  test("the settings + report steps take the API key from ORCAROUTER_API_KEY env and pass NO --key flag (argv-leak guard)", () => {
     const yml = actionYml();
     const blocks = {
-      "Fetch review settings": yml.slice(yml.indexOf("- name: Fetch review settings"), yml.indexOf("- name: Skip review (settings)")),
-      "Report run (cheap tier)": yml.slice(yml.indexOf("- name: Report run (cheap tier)"), yml.indexOf("- name: Report run (strong tier)")),
-      "Report run (strong tier)": yml.slice(yml.indexOf("- name: Report run (strong tier)"), yml.indexOf("- name: Clean up engine output")),
+      "Fetch review settings": sliceStep(yml, "- name: Fetch review settings", "- name: Skip review (settings)"),
+      "Report run": sliceStep(yml, "- name: Report run", "- name: Clean up engine output"),
     };
     for (const [name, block] of Object.entries(blocks)) {
       assert.match(block, /ORCAROUTER_API_KEY:/, `${name} must inject the key via ORCAROUTER_API_KEY env`);
@@ -408,17 +430,19 @@ describe("action.yml wiring (settings, quiet mode)", () => {
     }
   });
 
-  test("the summary step passes --held + --fix-first in the held branch so the ❌ count follows fix-first", () => {
+  test("the summary step has no held branch: the ❌ count follows block-on, never fix-first", () => {
+    // There is one review per push, so there is no run whose ❌ count should
+    // follow fix_first instead of block_on. If a --held branch comes back, the
+    // summary and the gate can disagree about what blocks the PR.
     const yml = actionYml();
-    const summary = yml.slice(yml.indexOf("- name: Summary (PR description)"), yml.indexOf("- name: Enforce severity gate"));
-    assert.match(summary, /FIX_FIRST: \$\{\{ steps\.settings\.outputs\.fix_first \}\}/, "the fix-first set must reach the summary step");
-    assert.match(summary, /HELD === 'true'/, "the held branch must be keyed off the cascade's held output");
-    assert.match(summary, /'--held', '--fix-first'/, "held runs must pass --held --fix-first to summary-comment.mjs");
+    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Enforce severity gate");
+    assert.doesNotMatch(summary, /--held/, "the summary must not pass --held");
+    assert.doesNotMatch(summary, /HELD/, "there is no held state to branch on");
   });
 
   test("the summary step passes the EFFECTIVE block-on set to summary-comment.mjs", () => {
     const yml = actionYml();
-    const summary = yml.slice(yml.indexOf("- name: Summary (PR description)"), yml.indexOf("- name: Enforce severity gate"));
+    const summary = sliceStep(yml, "- name: Summary (PR description)", "- name: Enforce severity gate");
     assert.match(summary, /--block-on/, "the ❌ count must follow the configured block-on set, not a hardcoded P0+P1");
     assert.match(summary, /steps\.settings\.outputs\.block_on/, "and it must be the settings-aware effective value");
   });

--- a/scripts/settings.test.mjs
+++ b/scripts/settings.test.mjs
@@ -406,6 +406,13 @@ describe("action.yml wiring (settings, quiet mode)", () => {
     // its output. Everything that enforces or measures reads the raw result.
     const reportOn = sliceStep(yml, "- name: report_on severity filter", "- name: Quiet mode filter");
     assert.match(reportOn, /\/result\.json/, "the report_on filter must read the unfiltered result");
+    // --show goes out UNCONDITIONALLY. report-filter.mjs reads an absent flag as
+    // "no setting, pass everything through" and an empty one as "only what
+    // blocks"; the settings step always writes a value (the disabled path writes
+    // every severity explicitly), so a `-n` guard here turned the configured
+    // "show only what blocks" into "show everything".
+    assert.match(reportOn, /--show "\$REPORT_ON"/, "the report_on filter must always receive --show");
+    assert.doesNotMatch(reportOn, /-n "\$REPORT_ON"/, "an empty report_on is a setting, not a missing one");
     const quiet = sliceStep(yml, "- name: Quiet mode filter", "- name: Post review comments");
     assert.match(quiet, /result-reported\.json/, "quiet must read the report_on-filtered copy, not the raw one");
 

--- a/scripts/summary-comment.mjs
+++ b/scripts/summary-comment.mjs
@@ -37,13 +37,13 @@
 // verdict itself always comes from --gate, which the driver computes with the
 // same configuration.
 //
-// HELD runs are the exception: when the cheap tier withheld the strong review
-// because a FIX-FIRST finding is present, the driver passes `--held`
-// `--fix-first <set>`. The block-on set may not include those severities (a
-// repo can even set block_on=""), so counting over block-on would render a
-// self-contradictory "❌ 0 findings block merge" next to the "held" tier line.
-// Under --held the ❌ count is taken over the fix-first set instead, so it
-// agrees with the held tier line and the ❌ verdict. Non-held is unchanged.
+// ALWAYS over block-on, with no exception. There used to be one: a held run —
+// a cheap pass withholding the strong review over a fix-first finding — counted
+// over the fix-first set instead, because block-on need not contain those
+// severities and "❌ 0 findings block merge" beside a "held" tier line
+// contradicts itself. There is no held run and no tier line now, so the count
+// and the gate read the same set, which is the property that matters: the
+// summary cannot claim something the merge gate does not enforce.
 
 import fs from "node:fs";
 import { SEVERITIES, countSeverities } from "./severity.mjs";

--- a/scripts/summary-comment.mjs
+++ b/scripts/summary-comment.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Edit-in-place PR summary comment for the OrcaCode Review cascade.
+// Edit-in-place PR summary comment for the OrcaCode Review action.
 //
 //   node summary-comment.mjs <result.json> --tier cheap|strong --push <n>
 //     --gate pass|blocked [--prev <file with the previous comment body>]
@@ -86,7 +86,6 @@ const blockOn = parseSet(opts.blockOn);
 const fixFirst = parseSet(opts.fixFirst);
 if (
   !file ||
-  !["cheap", "strong"].includes(opts.tier) ||
   !["pass", "blocked"].includes(opts.gate) ||
   !Number.isInteger(push) ||
   push < 1 ||
@@ -138,22 +137,22 @@ if (prev) {
 }
 lines.push("");
 
-if (opts.tier === "strong") {
-  lines.push(`Tier: STRONG (final pass) — ${opts.gate === "blocked" ? "blocked" : "pass"}`);
-} else if (opts.gate === "blocked") {
-  lines.push("Tier: CHEAP — held (fix P0/P1 first; the strong review runs once they're cleared)");
-} else {
-  lines.push("Tier: escalating to STRONG this run");
-}
-// Mode notes ride in the same status block as the tier line.
+// NO TIER LINE. It used to read "Tier: STRONG (final pass) — pass" and there is
+// one tier now, so the line said nothing the ✅/❌ verdict below does not already
+// say — and while the cascade existed it was also the only place a reader learned
+// their P0/P1 findings were withholding a second review. That mechanism is gone;
+// leaving its label behind would describe a decision nothing makes.
+//
+// Mode notes keep the status block they shared with it.
 if (passes > 1) lines.push(`exhaustive: ${passes} passes`);
 if (opts.quiet) lines.push("quiet mode: P2 shown in summary only");
 lines.push("");
 
-// A held run withheld escalation on fix-first findings, which block-on may not
-// cover — count over the fix-first set so the ❌ number agrees with the held
-// tier line and never renders "❌ 0 findings block merge". Non-held is unchanged.
-const blockingSet = opts.held ? fixFirst : blockOn;
+// Counted over block-on, which is what the gate enforces. The --held variant
+// (count over fix-first instead) went with the cascade: it existed so a withheld
+// escalation would not render "❌ 0 findings block merge" beside a held tier line,
+// and there is neither withholding nor a tier line any more.
+const blockingSet = blockOn;
 const blocking = blockingSet.reduce((n, s) => n + counts[s], 0);
 lines.push(
   opts.gate === "blocked"

--- a/scripts/summary-comment.test.mjs
+++ b/scripts/summary-comment.test.mjs
@@ -106,25 +106,6 @@ describe("severity table", () => {
   });
 });
 
-describe("tier-state line", () => {
-  test("cheap + blocked -> held", () => {
-    const out = run(["[P0] a"], ["--tier", "cheap", "--push", "1", "--gate", "blocked"]);
-    assert.match(out, /Tier: CHEAP — held \(fix P0\/P1 first/);
-  });
-
-  test("cheap + pass -> escalating to STRONG this run", () => {
-    const out = run(["[P2] nit"], ["--tier", "cheap", "--push", "1", "--gate", "pass"]);
-    assert.match(out, /Tier: escalating to STRONG this run/);
-  });
-
-  test("strong -> final pass, with the gate outcome", () => {
-    const pass = run([], ["--tier", "strong", "--push", "2", "--gate", "pass"]);
-    assert.match(pass, /Tier: STRONG \(final pass\) — pass/);
-    const blocked = run(["[P0] a"], ["--tier", "strong", "--push", "2", "--gate", "blocked"]);
-    assert.match(blocked, /Tier: STRONG \(final pass\) — blocked/);
-  });
-});
-
 describe("gate line", () => {
   test("blocked -> ❌ with the blocking (P0+P1) count", () => {
     const out = run(
@@ -186,49 +167,21 @@ describe("gate line", () => {
   });
 });
 
-describe("held run (cheap tier withheld escalation on fix-first findings)", () => {
-  test("held + empty --block-on: the ❌ count follows the FIX-FIRST set, never the contradictory '0 findings'", () => {
+describe("the ❌ count follows block-on", () => {
+  // What used to be the "held run" suite. The cascade could withhold the strong
+  // review on fix-first findings, and the count then had to follow FIX-FIRST or
+  // the summary read "❌ 0 findings block merge" beside a held tier line. There is
+  // no withholding any more, so what survives is the case that was never about
+  // held runs at all.
+  test("the count follows --block-on, not --fix-first", () => {
+    // --fix-first is deliberately a DIFFERENT set here: it used to steer this
+    // count on a held run, and now it must not steer it at all.
     const out = run(
-      ["[P0] a", "[P1] b", "[P2] c"],
-      // block_on='' would make the block-on count 0; --held must count fix-first (P0+P1=2).
-      ["--tier", "cheap", "--push", "1", "--gate", "blocked", "--block-on", "", "--held", "--fix-first", "P0,P1"],
+      ["[P0] a", "[P2] b"],
+      ["--push", "1", "--gate", "blocked", "--block-on", "P2", "--fix-first", "P0"],
     );
-    assert.match(out, /Tier: CHEAP — held/, `held tier line expected:\n${out}`);
-    assert.ok(out.includes("❌ 2 findings block merge"), `held count must be over fix-first, got:\n${out}`);
-    assert.ok(!out.includes("❌ 0 findings"), "a held run must never render the self-contradictory 0-count");
-  });
-
-  test("held count uses fix-first even when block-on covers different severities", () => {
-    const out = run(
-      ["[P0] a", "[P1] b"],
-      ["--tier", "cheap", "--push", "1", "--gate", "blocked", "--block-on", "P2", "--held", "--fix-first", "P0,P1"],
-    );
-    assert.ok(out.includes("❌ 2 findings block merge"), `got:\n${out}`);
-  });
-
-  test("a single held finding reads singular", () => {
-    const out = run(
-      ["[P0] only"],
-      ["--tier", "cheap", "--push", "1", "--gate", "blocked", "--block-on", "", "--held", "--fix-first", "P0,P1"],
-    );
-    assert.ok(out.includes("❌ 1 finding blocks merge"), `got:\n${out}`);
-  });
-
-  test("non-held behavior is unchanged: the count still follows --block-on", () => {
-    const out = run(
-      ["[P0] a", "[P2] b", "[P2] c"],
-      ["--tier", "strong", "--push", "1", "--gate", "blocked", "--block-on", "P2"],
-    );
-    assert.ok(out.includes("❌ 2 findings block merge"), `got:\n${out}`);
-  });
-
-  test("an unknown severity in --fix-first exits 2 — a wiring bug must be loud", () => {
-    const r = spawnSync(
-      "node",
-      [SUMMARY, join(dir, "x.json"), "--tier", "cheap", "--push", "1", "--gate", "blocked", "--held", "--fix-first", "P0,P9"],
-      { encoding: "utf8" },
-    );
-    assert.equal(r.status, 2);
+    assert.ok(out.includes("❌ 1 finding blocks merge"), `got:
+${out}`);
   });
 });
 
@@ -286,9 +239,11 @@ describe("robustness", () => {
   test("bad usage (missing/invalid flags) exits 2 — a wiring bug must be loud", () => {
     for (const args of [
       [],
-      ["--tier", "cheap", "--push", "1"], // no --gate
-      ["--tier", "mid", "--push", "1", "--gate", "pass"], // bad tier
-      ["--tier", "cheap", "--push", "zero", "--gate", "pass"], // bad push
+      ["--push", "1"], // no --gate
+      ["--push", "zero", "--gate", "pass"], // bad push
+      // No bad-tier case: --tier is no longer validated here. There is one tier,
+      // the summary stopped rendering it, and the value the control plane records
+      // is checked by report.mjs and the gateway instead.
     ]) {
       const r = spawnSync("node", [SUMMARY, join(dir, "x.json"), ...args], { encoding: "utf8" });
       assert.equal(r.status, 2, `args ${JSON.stringify(args)} must exit 2`);

--- a/skills/setup-orca-code-review/SKILL.md
+++ b/skills/setup-orca-code-review/SKILL.md
@@ -197,7 +197,8 @@ in the file only wins if it differs from its documented default.
 **If the file is authoritative (`settings: "false"`)** — edit it. Ask with
 `AskUserQuestion` which knobs to change, offering only what is relevant:
 
-- Merge policy (`block-on`) and fix-first escalation (`fix-first`).
+- Merge policy (`block-on`), exhaustive early-stop (`fix-first`), and which severities post
+  inline (Report severities, dashboard-only).
 - Diff limits (`max-diff-kb`, `max-diff-files`) and `on-oversized-diff`.
 - Precision filter (`precision-filter`, `judge-model`, `judge-threshold`).
 - Run reporting (`report`) and token metering (`meter`).

--- a/skills/setup-orca-code-review/assets/workflow.yml
+++ b/skills/setup-orca-code-review/assets/workflow.yml
@@ -52,7 +52,7 @@ jobs:
           #
           # settings: "true"            # "false" = this file is authoritative
           # block-on: "P0,P1"           # severities that fail the check
-          # fix-first: "P0,P1"          # withhold the strong tier until fixed
+          # fix-first: "P0,P1"          # exhaustive only: stop adding passes once found
           # on-oversized-diff: "fail"   # "pass" makes an oversized skip advisory
           # auto-review-authors: ""     # public repos: e.g. "OWNER,MEMBER,COLLABORATOR,CONTRIBUTOR"
           # max-diff-kb: "512"

--- a/skills/setup-orca-code-review/references/inputs.md
+++ b/skills/setup-orca-code-review/references/inputs.md
@@ -23,7 +23,7 @@ answering a question about behavior — do not guess a default.
 
 | Input | Default | What it does |
 | --- | --- | --- |
-| `fix-first` | `P0,P1` | Severities that withhold the strong tier until fixed at the cheap tier. |
+| `fix-first` | `P0,P1` | Severities that stop an exhaustive review early — that finding is what to fix first. No effect unless `exhaustive` is on, and it never changes what the reviewer is asked to look for. |
 | `block-on` | `P0,P1` | Severities that fail the check and block the merge. `""` means never block. |
 
 Values are `P0`, `P1`, `P2`, comma-separated, case-insensitive. An explicit
@@ -99,7 +99,7 @@ and only apply when `settings` is `true`.
 | --- | --- | --- |
 | `auto_review` | on / off | Master switch for automatic reviews. |
 | `trigger` | `every_push`, `ready_for_review`, `on_demand` | When an automatic review fires. `ready_for_review` skips drafts. |
-| `exhaustive` | on / off | Extra engine passes on the strong tier, deduped. Costs more. |
+| `exhaustive` | on / off | Extra engine passes over the same diff, deduped. Costs more. |
 | `quiet` | on / off | Mutes P2 at posting time. The gate and the run report still see true counts. |
 | `rubric` | free text | Server-side rubric override for the review prompt. |
 | Models | per tier | Which model runs each tier. The action never names a model. |

--- a/workflows/orca-code-review.yml
+++ b/workflows/orca-code-review.yml
@@ -58,7 +58,7 @@ jobs:
           # orcarouter-url: ${{ secrets.ORCAROUTER_URL }}
           # brand: "OrcaCode Review"
           # router: "orcarouter/code-review"  # router whose DSL picks the model
-          # fix-first: "P0,P1"   # ask for a concrete fix on these first
+          # fix-first: "P0,P1"   # exhaustive only: stop adding passes once one is found
           # block-on: "P0"       # fail the check (block merge) on these
           # max-diff-kb: "512"   # bigger diffs skip the review (outcome: on-oversized-diff)
           # max-diff-files: "300"  # same skip when the diff touches more files than this

--- a/workflows/orca-code-review.yml
+++ b/workflows/orca-code-review.yml
@@ -4,9 +4,8 @@
 # `ORCAROUTER_API_KEY`. The review logic lives in the published action, so you
 # never copy scripts or config — just bump the version tag to update.
 #
-# Cost-tiered cascade: the cheap model reviews every push and the strong model
-# is withheld while any P0/P1 remains (fix those first). Only once the cheap tier
-# is clear does the strong model run the final pass. A severity gate can fail the
+# One review per push: findings post as inline PR comments, and a severity gate
+# can fail the
 # check to block the merge — mark it "required" in branch protection.
 
 name: OrcaCode Review
@@ -17,7 +16,6 @@ concurrency:
 
 on:
   # `synchronize` re-reviews on every new push — the per-commit review loop. The
-  # cascade escalates to the strong tier within a single run (no label-triggered
   # re-run needed — and a GITHUB_TOKEN label change can't trigger one anyway).
   # `ready_for_review` makes the dashboard's trigger=ready_for_review mode fire
   # when a draft PR becomes ready (drafts are skipped in that mode).
@@ -29,7 +27,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  issues: write # label-based tier state + clean/fallback PR comments
+  issues: write # clean/fallback PR comments
 
 jobs:
   review:
@@ -59,8 +57,8 @@ jobs:
           # All optional — uncomment to override the defaults:
           # orcarouter-url: ${{ secrets.ORCAROUTER_URL }}
           # brand: "OrcaCode Review"
-          # router: "orcarouter/code-review"  # router whose DSL picks the model per tier
-          # fix-first: "P0,P1"   # withhold the strong tier until these are fixed
+          # router: "orcarouter/code-review"  # router whose DSL picks the model
+          # fix-first: "P0,P1"   # ask for a concrete fix on these first
           # block-on: "P0"       # fail the check (block merge) on these
           # max-diff-kb: "512"   # bigger diffs skip the review (outcome: on-oversized-diff)
           # max-diff-files: "300"  # same skip when the diff touches more files than this


### PR DESCRIPTION
The recipe routes every branch to one model and `action.yml` has hardcoded `PASSES=1` with no promotion for a while now. This removes what was left of the two-tier machinery, and adds the publish-side severity filter the dashboard already offers but the Action ignored.

## Single tier

`action.yml` goes 22 steps → 21. Removed:

- the PR-label read — one fewer paginated API call on every run
- the `Promote tier` step
- the second per-tier report step, which was guarded on an output nothing writes any more, so it could never run
- `TIER_STATE`, `RESULT_CHEAP`, `PROMOTE`, `HELD`, `strong_ran` and all their consumers

The tier sent to the control plane is now `standard`. It used to be `strong`, from when a cheap pass could escalate to a strong one — with a single pass the label described which reviewer picked a finding up rather than anything about the run. `RESULT_STRONG` → `RESULT_FINAL`, `result-strong.json` → `result-final.json`.

`summary-comment.mjs` loses the `Tier:` line, and the blocking count now always follows `--block-on`. It used to follow `--fix-first` on a held run, which meant the summary and the merge gate could report different answers to "what is blocking this PR".

## report_on

New `scripts/report-filter.mjs`, applied between the engine and the quiet filter:

```
result.json → result-reported.json → result-posted.json
                (report_on)            (quiet)
```

- The published set is **report_on ∪ block_on**. A severity that blocks the merge can never be withheld from the timeline — otherwise a PR would fail its gate with nothing on the diff explaining why.
- No `report_on` at all (a gateway that predates the field) is pass-through. An empty value means "only what blocks".
- An unknown severity in the list exits 2 rather than guessing.

The merge gate and the run report keep reading the unfiltered `result.json`. Display filtering never moves enforcement or the numbers.

## Docs and template

README, the workflow template and both recipes now describe one review per push. `exhaustive` is described as additional passes over the same diff, which is what it does.

## Tests

Two structural suites had rotted quietly and this is worth calling out. `settings.test.mjs` and `fact-proxy.test.mjs` sliced `action.yml` with a bare `indexOf` pair; when a boundary step is renamed or removed, `indexOf` returns -1, `slice(start, -1)` runs to the end of the file, and every assertion in the test matches against most of `action.yml` — passing for the wrong reason. Both now go through a `sliceStep` helper that asserts both boundaries exist.

`report.test.mjs` now asserts `invocations.length === guards.length` over `node "$REPORT"` rather than a fixed count, so the "every report call sits behind the `report` input" invariant holds no matter how many report steps there are.

Local: 21 test files pass. Four failures remain on my Windows box in `settings`/`report`/`installer`/`platforms`, all pre-existing on `main` (repeated in-process HTTP servers crash node with `0xC0000409`) — same count as the baseline, one fewer in `settings`.

## Order of operations

The control plane needs to accept `standard` before this ships, or the run report is dropped — silently, since reporting is best-effort. That side is already merged and awaiting deploy.
