### PR TITLE
feat(skill): offer Action or GitHub App mode, and check the permission first

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Skills for OrcaRouter products.",
-    "version": "1.2.0"
+    "version": "1.2.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Skills for OrcaRouter products.",
-    "version": "1.2.1"
+    "version": "1.3.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orca-code-review",
   "description": "Set up, reconfigure, troubleshoot, and remove OrcaCode Review — AI pull-request review powered by OrcaRouter — in any GitHub repository.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Continuum-AI-Corp",
     "url": "https://github.com/Continuum-AI-Corp"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orca-code-review",
   "description": "Set up, reconfigure, troubleshoot, and remove OrcaCode Review — AI pull-request review powered by OrcaRouter — in any GitHub repository.",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": {
     "name": "Continuum-AI-Corp",
     "url": "https://github.com/Continuum-AI-Corp"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -200,26 +200,39 @@ jobs:
           set -uo pipefail
           NAME='${{ steps.check.outputs.name }}'
           VERSION='${{ steps.check.outputs.version }}'
-          # No auth header here on purpose — an authenticated read would succeed
-          # against a private package and prove nothing.
-          URL="https://registry.npmjs.org/$(node -pe 'encodeURIComponent(process.argv[1])' "$NAME")/$VERSION"
-          # Three minutes. A brand-new version document takes a while to reach
-          # the public CDN edge — 1.1.0 needed longer than the first sixty
-          # seconds this waited, and failed a build that had shipped correctly.
-          # A restricted package and an unpropagated one both answer 404, so
-          # the status code cannot shorten this; only time can.
-          for attempt in $(seq 1 15); do
-            CODE=$(curl -sS -o /dev/null -w '%{http_code}' "$URL" || echo 000)
-            echo "attempt $attempt/15: HTTP $CODE"
-            if [ "$CODE" = "200" ]; then
-              echo "$NAME@$VERSION is publicly installable"
+          ENCODED=$(node -pe 'encodeURIComponent(process.argv[1])' "$NAME")
+
+          # Fetch the PACKUMENT, not the per-version document.
+          #
+          # `npm install` reads the packument and picks a version out of it, so
+          # that is the document whose freshness actually decides whether a
+          # stranger can install. The /<name>/<version> route is a colder path:
+          # it 404'd for more than three minutes after two correct publishes,
+          # failing builds that had shipped fine. Checking the wrong document
+          # was the bug, not the timeout.
+          #
+          # No auth header on purpose — an authenticated read succeeds against a
+          # restricted package and would prove nothing.
+          for attempt in $(seq 1 20); do
+            BODY=$(curl -sS -H 'Cache-Control: no-cache' "https://registry.npmjs.org/$ENCODED" || echo '')
+            FOUND=$(printf '%s' "$BODY" | node -pe '
+              try {
+                const d = JSON.parse(require("fs").readFileSync(0, "utf8"));
+                d.versions?.[process.argv[1]] ? "yes" : "no";
+              } catch { "no" }
+            ' "$VERSION" 2>/dev/null || echo no)
+
+            if [ "$FOUND" = "yes" ]; then
+              echo "$NAME@$VERSION is in the public packument — installable"
               exit 0
             fi
-            sleep 12
+            echo "attempt $attempt/20: not in the public packument yet"
+            sleep 15
           done
-          echo "::error::$NAME@$VERSION published but is still not anonymously readable after 3 minutes (HTTP $CODE)."
+
+          echo "::error::$NAME@$VERSION published but is absent from the public packument after 5 minutes."
           echo "::error::Either it is restricted — fix with: npm access set status=public $NAME"
-          echo "::error::or the CDN is unusually slow. Check $URL by hand before assuming the former."
+          echo "::error::or the CDN is unusually slow. Check https://registry.npmjs.org/$ENCODED by hand."
           exit 1
 
       - name: Summary

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -107,14 +107,20 @@ Five gates run before the point of no return, and each one fails the job:
 And one gate *after* publishing, because that is the only place it can be
 checked:
 
-6. The new version is fetched from the registry **anonymously** and must return
-   200, retried for three minutes. `npm publish` exiting 0 does not mean anyone
-   can install what it shipped.
+6. The new version must appear in the **public packument**, fetched
+   anonymously and retried for five minutes. `npm publish` exiting 0 does not
+   mean anyone can install what it shipped.
 
-   The window is that long because a restricted package and one that simply has
-   not reached the CDN edge yet both answer 404 — the status code cannot tell
-   them apart, so only waiting can. A red gate 6 therefore means *check the URL
-   by hand* before assuming the package is private.
+   It polls `registry.npmjs.org/<name>` — the document `npm install` actually
+   reads to pick a version — rather than the `/<name>/<version>` route. That
+   distinction is not cosmetic: the per-version route stayed 404 for over three
+   minutes after two correct publishes and failed both builds. Checking a
+   document nobody installs from was the bug; the timeout was a symptom.
+
+   Anonymous on purpose — an authenticated read succeeds against a restricted
+   package and proves nothing. A restricted package and an unpropagated one
+   look alike, so a red gate 6 still means *check the URL by hand* before
+   concluding the package is private.
 
 Gate 6 exists because `@orcarouter/code-review@1.0.2` published green and was
 unreachable. Scoped packages default to **restricted**, and it landed that way

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcarouter/code-review",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "One-command installer for OrcaCode Review — AI pull-request review powered by OrcaRouter.",
   "bin": {
     "orcacode-review": "bin/orcacode-review.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcarouter/code-review",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "One-command installer for OrcaCode Review — AI pull-request review powered by OrcaRouter.",
   "bin": {
     "orcacode-review": "bin/orcacode-review.mjs"

--- a/scripts/installer.test.mjs
+++ b/scripts/installer.test.mjs
@@ -213,3 +213,43 @@ test("the skill closes by listing the key as an outstanding user action", () => 
 test("the skill refuses to call an install complete without the secret", () => {
   assert.match(SKILL, /[Dd]o not report the\s+install as complete while the secret is missing/s);
 });
+
+// ------------------------------------------------------------ install modes ---
+
+test("the skill offers both install modes and routes between them", () => {
+  assert.match(SKILL, /## Install — GitHub App mode/);
+  assert.match(SKILL, /GitHub Action \(recommended\)/);
+  assert.match(SKILL, /https:\/\/github\.com\/apps\/orcacode-review\/installations\/new/);
+});
+
+test("App mode warns about the permission before offering the choice", () => {
+  // Walking a plain org member to an approval page they will be stopped at is
+  // the whole failure this ordering exists to avoid.
+  const pick = SKILL.slice(SKILL.indexOf("### 0. Pick the mode"), SKILL.indexOf("### 1. Preflight"));
+  assert.match(pick, /permissions\.admin/, "no repo-permission probe");
+  assert.match(pick, /memberships/, "no org-role probe");
+  assert.match(pick, /organization owner/i);
+  assert.ok(
+    pick.indexOf("admin: false") < pick.indexOf("Chose App mode?"),
+    "the cannot-approve warning must come before the routing line",
+  );
+});
+
+test("App mode never claims the install can be automated", () => {
+  const app = SKILL.slice(SKILL.indexOf("## Install — GitHub App mode"), SKILL.indexOf("## Do not install both"));
+  assert.match(app, /no REST endpoint that installs an\s+App/s);
+  // Printing the URL matters more than opening it: SSH, containers and CI have
+  // no browser, and a silent `open` leaves the user waiting on nothing.
+  assert.match(app, /never open it without printing it/i);
+  // The repo secret belongs to Action mode only.
+  assert.match(app, /No `ORCAROUTER_API_KEY` secret is needed/);
+});
+
+test("the double-install conflict is documented in both places", () => {
+  assert.match(SKILL, /## Do not install both/);
+  const trouble = fs.readFileSync(
+    new URL("../skills/setup-orca-code-review/references/troubleshooting.md", import.meta.url),
+    "utf8",
+  );
+  assert.match(trouble, /two sets of comments/i);
+});

--- a/scripts/installer.test.mjs
+++ b/scripts/installer.test.mjs
@@ -188,3 +188,28 @@ test("every npx invocation in the README names the real package", () => {
     assert.equal(name, PKG.name, `stale package name in README: npx ${name}`);
   }
 });
+
+// ------------------------------------------------------- skill safety rules ---
+
+const SKILL = fs.readFileSync(
+  new URL("../skills/setup-orca-code-review/SKILL.md", import.meta.url),
+  "utf8",
+);
+
+test("the skill tells the agent to hand the API key to gh, not handle it", () => {
+  // The one instruction that must never be softened. An agent that reads the
+  // key to be helpful puts it in the transcript, permanently.
+  assert.match(SKILL, /gh secret set ORCAROUTER_API_KEY/);
+  assert.match(SKILL, /[Nn]ever.{0,80}paste the key into the chat/s);
+  assert.match(SKILL, /\bps\b/, "the argv/ps rationale is missing — rules without reasons get edited away");
+});
+
+test("the skill closes by listing the key as an outstanding user action", () => {
+  const report = SKILL.slice(SKILL.indexOf("### 8."), SKILL.indexOf("## Reconfigure"));
+  assert.match(report, /gh secret set ORCAROUTER_API_KEY/, "the final step does not repeat the gh command");
+  assert.match(report, /copy-pasteable/i);
+});
+
+test("the skill refuses to call an install complete without the secret", () => {
+  assert.match(SKILL, /[Dd]o not report the\s+install as complete while the secret is missing/s);
+});

--- a/skills/setup-orca-code-review/SKILL.md
+++ b/skills/setup-orca-code-review/SKILL.md
@@ -101,27 +101,41 @@ from spending your quota with `/orcacode-review`.
 
 Show the user the final file before committing.
 
-### 4. Add the API key secret
+### 4. Have the user add the API key — with `gh`, themselves
 
 The secret must be named exactly `ORCAROUTER_API_KEY`.
 
-**Never ask the user to paste the key into the chat, and never read it from a file.**
-It would land in the transcript. Instead, tell them to run it themselves in this session:
+This is the one step you do **not** perform. Stop, hand the user this command,
+and wait for them to confirm they have run it:
 
 ```
 ! gh secret set ORCAROUTER_API_KEY --repo <owner/name>
 ```
 
-`gh` prompts for the value and it never reaches you. Without `gh`, send them to
-`https://github.com/<owner>/<name>/settings/secrets/actions/new`.
+`gh` prompts for the value on their terminal, so the key goes from their
+keyboard straight to GitHub. It never passes through you.
+
+**Never** ask them to paste the key into the chat, read it out of a file or an
+env var, or pass it on a command line. A pasted key is in the transcript
+forever; a key in `argv` is visible to every process on the machine via `ps`.
+There is no version of this you can do "carefully" — the only safe handling is
+not handling it.
 
 They can create or copy a key at <https://www.orcarouter.ai/console/token>.
 
-Then verify it exists without revealing it:
+Without `gh`, send them to
+`https://github.com/<owner>/<name>/settings/secrets/actions/new` and have them
+add it in the browser.
+
+Then confirm it exists without ever seeing its value:
 
 ```bash
 gh secret list --repo <owner/name> | grep ORCAROUTER_API_KEY
 ```
+
+If it is not there yet, do not continue to the test PR — the run will fail on
+auth and the failure will look like a configuration bug rather than a missing
+key. Wait, or skip to step 8 and list it as outstanding.
 
 ### 5. Enable the app
 
@@ -150,11 +164,24 @@ gh api -X PATCH repos/<owner>/<name>/branches/<default>/protection/required_stat
 
 Confirm before running — branch protection changes affect everyone on the repo.
 
-### 8. Report
+### 8. Report, and close on what they still owe
 
 Tell the user, concretely: the workflow path, the settings you chose, whether the
 secret and required check are in place, and the result of the test run. If any step
-was skipped (no `gh`, protection not applied), say which and what they still owe.
+was skipped (no `gh`, protection not applied), say which.
+
+**End the message with their outstanding actions as copy-pasteable commands** —
+not prose describing them. Anything you could not do yourself belongs here, and
+the API key is almost always on the list because you are not allowed to do it:
+
+```
+! gh secret set ORCAROUTER_API_KEY --repo <owner/name>
+```
+
+Re-check with `gh secret list` before claiming it is done. Do not report the
+install as complete while the secret is missing: the workflow is in place but
+every run will fail on auth, and "installed" would be a lie the user only finds
+out about on their next PR.
 
 ## Reconfigure
 

--- a/skills/setup-orca-code-review/SKILL.md
+++ b/skills/setup-orca-code-review/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: setup-orca-code-review
-description: Set up, reconfigure, troubleshoot, or remove OrcaCode Review — AI pull-request review powered by OrcaRouter — in a GitHub repository. Handles the whole lifecycle end to end without asking the user to run a CLI. Use whenever the user mentions OrcaCode Review, OrcaRouter code review, "@orcarouter code review", or /orcacode-review, and whenever they ask to set up AI code review on a repo, add the orca-code-review action, change which severities block merges, find out why a review did not run or did not post findings, or take the review workflow back out.
+description: Set up, reconfigure, troubleshoot, or remove OrcaCode Review — AI pull-request review powered by OrcaRouter — in a GitHub repository. Handles the whole lifecycle end to end without asking the user to run a CLI. Use whenever the user mentions OrcaCode Review, OrcaRouter code review, "@orcarouter code review", or /orcacode-review, and whenever they ask to set up AI code review on a repo, add the orca-code-review action, change which severities block merges, find out why a review did not run or did not post findings, take the review workflow back out, or install the OrcaCode Review GitHub App instead of the Action.
 ---
 
 # OrcaCode Review
 
-OrcaCode Review is a GitHub composite action that reviews every pull request with
-an LLM, posts findings as inline comments, and fails a status check when serious
-issues are found. Model selection lives in OrcaRouter, not in the workflow file.
+OrcaCode Review reviews every pull request with an LLM, posts findings as inline
+comments, and fails a status check when serious issues are found. Model selection
+lives in OrcaRouter, not in the repo.
+
+It runs one of two ways, and a repo should use exactly one:
+
+- **GitHub Action** — a workflow file plus one secret. Needs write access.
+  The default, and the only one an agent can complete end to end.
+- **GitHub App** — a bot, nothing in the repo. Needs repo admin or org owner,
+  and a human to approve the install in a browser.
 
 **Severity contract:** `P0` critical / `P1` high → ❌ block. `P2` advisory → 💬 comment.
 
@@ -19,7 +26,8 @@ run an installer; that is what this skill replaces.
 
 | The user says something like… | You do |
 | --- | --- |
-| "set up OrcaCode Review here", "@orcarouter code review 帮我配置这个仓库" | [Install](#install) |
+| "set up OrcaCode Review here", "@orcarouter code review 帮我配置这个仓库" | [Install](#install) — offer Action vs App first |
+| "install the GitHub App instead", "用 App 模式" | [App mode](#install--github-app-mode) |
 | "only block P0", "move the config to the dashboard", "raise the diff limit" | [Reconfigure](#reconfigure) |
 | "why didn't the review run?", "no comments appeared", "the check is stuck red" | [Troubleshoot](#troubleshoot) |
 | "remove OrcaCode Review", "turn the review off" | [Uninstall](#uninstall) |
@@ -42,6 +50,39 @@ If `gh` is missing or unauthenticated, everything still works — you just hand 
 user web URLs instead of running commands. Say so once and move on.
 
 ## Install
+
+There are two ways to run OrcaCode Review on a repo. Pick one — **never both**,
+see [Do not install both](#do-not-install-both).
+
+### 0. Pick the mode
+
+Check what the user is even able to do *before* offering the choice, so you do
+not walk them into an approval they cannot give:
+
+```bash
+gh api /repos/<owner>/<name> --jq '{admin: .permissions.admin, ownerType: .owner.type, owner: .owner.login}'
+# for an Organization owner, also:
+gh api /orgs/<owner>/memberships/$(gh api /user --jq .login) --jq .role   # "admin" | "member"
+```
+
+Then ask with `AskUserQuestion`:
+
+**"How should OrcaCode Review run on this repo?"**
+
+- *GitHub Action (recommended)* — a workflow file in the repo plus one secret.
+  Anyone with **write access** can set it up, it works on personal repos, and
+  the config is visible in the diff like any other CI. This is the path the
+  rest of this section describes.
+- *GitHub App* — no file in the repo; a bot reviews PRs. Needs **repo admin, or
+  organization owner** on an org repo. One approval can cover many repos.
+
+**If the probe above said `admin: false` and the org role is `member`, say so
+before they choose.** They cannot complete App mode themselves — they would
+click through to the approval page and be stopped there. Offer Action mode, or
+offer to draft the request they send to an owner.
+
+Chose App mode? → [Install — GitHub App mode](#install--github-app-mode).
+Otherwise carry on.
 
 ### 1. Preflight
 
@@ -137,10 +178,13 @@ If it is not there yet, do not continue to the test PR — the run will fail on
 auth and the failure will look like a configuration bug rather than a missing
 key. Wait, or skip to step 8 and list it as outstanding.
 
-### 5. Enable the app
+### 5. Switch it on in the OrcaRouter console
 
 Point the user at **OrcaRouter → Apps → OrcaCode Review** (<https://www.orcarouter.ai/>)
-to turn the app on and choose review models. Reviews will not run until it is enabled.
+to turn it on and choose review models. Reviews will not run until it is enabled.
+
+This is the OrcaRouter console, not the GitHub App — Action mode still needs it.
+There is no API for this step today, so it is the user's to do.
 
 ### 6. Commit and open a test PR
 
@@ -182,6 +226,110 @@ Re-check with `gh secret list` before claiming it is done. Do not report the
 install as complete while the secret is missing: the workflow is in place but
 every run will fail on auth, and "installed" would be a lie the user only finds
 out about on their next PR.
+
+## Install — GitHub App mode
+
+No file lands in the repo. OrcaRouter reviews pull requests as a bot, and the
+repo's own config is the App's installation rather than a workflow.
+
+### 1. Confirm they can actually approve it
+
+Installing a GitHub App is a **permission grant**, so GitHub requires a human to
+approve it on an authorization page. There is no REST endpoint that installs an
+App on someone's behalf — this is deliberate, not a gap you can route around.
+
+The approver must be **repo admin**, or an **organization owner** for an org
+repo. If the step-0 probe showed otherwise, stop here and offer:
+
+- Action mode instead, which only needs write access, or
+- a message they can forward to an owner, containing the install link below and
+  one line on what it does.
+
+### 2. Hand over the link
+
+Print the URL. Offer to open it, but **never open it without printing it** —
+SSH sessions, containers and CI have no browser, and a tool that silently
+launches nothing leaves the user waiting on something that will not happen.
+
+```
+https://github.com/apps/orcacode-review/installations/new
+```
+
+To open it as well:
+
+```bash
+open <url>        # macOS
+xdg-open <url>    # Linux
+```
+
+Tell them what to expect on that page: choose the account or organization, then
+**select only this repository** unless they mean to cover more. "All
+repositories" is a much larger grant, and on a paid plan a much larger bill.
+
+### 3. Wait, then verify
+
+Ask them to say when the approval is done — do not poll silently and do not
+assume.
+
+Verification depends on what their token can see:
+
+```bash
+# Works only with the admin:org scope, which they may not want to grant:
+gh api /orgs/<owner>/installations --jq '.installations[].app_slug'
+```
+
+`GET /repos/{owner}/{repo}/installation` does **not** work here — it needs the
+App's own JWT, which no user token can produce.
+
+If neither is available, verify the honest way: open a pull request and look for
+the bot's review. That is the same thing the user cares about anyway.
+
+```bash
+gh pr create --fill
+```
+
+### 4. Configure
+
+Everything else lives at **OrcaRouter → Apps → OrcaCode Review**
+(<https://www.orcarouter.ai/>): models, review mode, severity rules, merge
+policy, rubric.
+
+**No `ORCAROUTER_API_KEY` secret is needed in the repo** — the App carries its
+own credentials. Do not add one; it would sit there unused and look load-bearing
+to the next person who reads the settings page.
+
+### 5. Make the gate real
+
+The App posts its own status check. Read the exact check name off the test PR
+rather than guessing it:
+
+```bash
+gh pr checks <number>
+```
+
+Then require that check under **Settings → Branches / Rulesets → Require status
+checks to pass**. Until it is required, a red check blocks nothing.
+
+### 6. Report
+
+Same rules as Action mode: what is in place, what is not, and any outstanding
+action as a copy-pasteable command. If the approval never happened, say the
+install is **not** complete — an unapproved App reviews nothing and reports no
+error.
+
+## Do not install both
+
+The Action and the App both review the same pull requests. Running them together
+gives every PR two sets of comments and bills two reviews.
+
+Before installing either, check for the other:
+
+- Action present → `.github/workflows/orca-code-review.yml` exists on the base branch.
+- App present → a bot review or an extra check on a recent PR.
+
+If the user has one and wants the other, remove the first — [Uninstall](#uninstall)
+for the Action, or the App's own page on GitHub for the App. Removing the Action
+is the reversible one, so prefer that direction when they are unsure.
 
 ## Reconfigure
 

--- a/skills/setup-orca-code-review/references/troubleshooting.md
+++ b/skills/setup-orca-code-review/references/troubleshooting.md
@@ -81,6 +81,21 @@ Fix by pinning a newer tag or an immutable commit SHA instead of `@v1`.
   the same model is not an independent second opinion.
 - Turn on quiet mode to keep P2 out of the PR while still counting it.
 
+## Every PR gets two sets of comments
+
+The Action and the GitHub App are both installed. They review the same pull
+requests independently, so the repo pays twice and the author reads everything
+twice.
+
+| Check | How |
+| --- | --- |
+| Action present | `git show origin/<default>:.github/workflows/orca-code-review.yml` |
+| App present | A bot review, or a check on a recent PR that no workflow in the repo produces |
+
+Keep one. Removing the Action is the reversible half — delete the workflow (drop
+the required check first). Removing the App means revoking its installation on
+GitHub, which is a permission change someone with admin rights has to make.
+
 ## Merges are not actually blocked
 
 A red check blocks nothing until it is required. Add **`review`** under


### PR DESCRIPTION
The App exists at `github.com/apps/orcacode-review`, but the skill only knew about the Action. Now it asks which, and routes.

## The ordering is the point

It probes what the user can actually do **before** offering the choice:

```bash
gh api /repos/<o>/<n> --jq .permissions.admin
gh api /orgs/<o>/memberships/<user> --jq .role
```

Installing a GitHub App is a **permission grant** — GitHub requires a human to approve it on an authorization page, and there is no REST endpoint that does it on someone's behalf. That is deliberate, not a gap.

So offering App mode to a plain org member walks them to a page that stops them. Verified against this repo:

```
{"admin": false, "owner": "Continuum-AI-Corp", "ownerType": "Organization"}
role: member
```

The account we've been running all day could not complete App mode. The skill now says that up front instead of finding out three steps in.

## App mode hands over a link

```
https://github.com/apps/orcacode-review/installations/new
```

It **prints** the URL and only optionally opens it. A tool that silently calls `open` in an SSH session, a container, or CI leaves the user waiting on a browser that will never appear.

It also tells them to pick *this repository* rather than "all repositories" — a much larger grant, and on a paid plan a much larger bill.

## Verification is honest about its limits

| Route | Why not |
| --- | --- |
| `GET /repos/{o}/{r}/installation` | Needs the App's own JWT. No user token can produce one — confirmed, returns 401. |
| `GET /orgs/{o}/installations` | Needs `admin:org`. Not worth asking a user to grant write-level org scope to read one flag. |

Fallback: open a PR and look for the bot review. Same thing the user actually cares about.

## The failure mode this choice creates

Both installed → two reviews per PR, double spend. Documented in the skill and in `troubleshooting.md`, with the note that **removing the Action is the reversible half** — revoking an App installation is a permission change only an admin can make.

## Also

Renames Action step 5 from "Enable the app". It means the OrcaRouter console, which now reads as the GitHub App and would send people to the wrong place entirely.

## Tests

Four new, pinning the parts that would rot quietly: both modes present and linked, the permission warning ordered before the routing line, no claim that the install is automatable, the `open`-without-printing rule, and the conflict documented in both files. 389 passing.

1.3.0 — merging publishes it.