### PR TITLE
docs: drop the tier label from docs that outlived it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Skills for OrcaRouter products.",
-    "version": "1.3.0"
+    "version": "1.3.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orca-code-review",
   "description": "Set up, reconfigure, troubleshoot, and remove OrcaCode Review — AI pull-request review powered by OrcaRouter — in any GitHub repository.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "Continuum-AI-Corp",
     "url": "https://github.com/Continuum-AI-Corp"

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
     required: false
     default: "https://api.orcarouter.ai/v1/chat/completions"
   github-token:
-    description: "Token used to fetch the PR head, post review comments, and manage the tier label."
+    description: "Token used to fetch the PR head, post review comments, and react to a /orcacode-review command."
     required: false
     default: ${{ github.token }}
   brand:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcarouter/code-review",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "One-command installer for OrcaCode Review — AI pull-request review powered by OrcaRouter.",
   "bin": {
     "orcacode-review": "bin/orcacode-review.mjs"

--- a/scripts/installer.test.mjs
+++ b/scripts/installer.test.mjs
@@ -253,3 +253,58 @@ test("the double-install conflict is documented in both places", () => {
   );
   assert.match(trouble, /two sets of comments/i);
 });
+
+// ------------------------------------------- the two workflow copies agree ---
+
+// `workflows/orca-code-review.yml` (the repo's example) and the skill's
+// `assets/workflow.yml` (the one written into a user's repo) are the same file
+// with different prose. When #28 retired the review cascade it updated the
+// example and missed the skill's copy, so every new install kept getting a
+// `permissions:` comment describing a tier label that no longer exists.
+//
+// Comments drift silently. The machine-readable parts must not.
+
+const readYaml = (rel) => fs.readFileSync(new URL(rel, import.meta.url), "utf8");
+const EXAMPLE = readYaml("../workflows/orca-code-review.yml");
+const TEMPLATE = readYaml("../skills/setup-orca-code-review/assets/workflow.yml");
+
+// Strips comments and blank lines, leaving only what GitHub actually reads.
+const effective = (yaml) =>
+  yaml
+    .split("\n")
+    .map((l) => l.replace(/\s+#.*$/, "").trimEnd())
+    .filter((l) => l.trim() && !l.trim().startsWith("#"))
+    .join("\n");
+
+const section = (yaml, key) => {
+  const lines = effective(yaml).split("\n");
+  const start = lines.findIndex((l) => l === `${key}:`);
+  if (start === -1) return null;
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((l) => /^\S/.test(l));
+  return [lines[start], ...(end === -1 ? rest : rest.slice(0, end))].join("\n");
+};
+
+for (const key of ["permissions", "on", "concurrency"]) {
+  test(`the example workflow and the skill template agree on \`${key}:\``, () => {
+    const a = section(EXAMPLE, key);
+    const b = section(TEMPLATE, key);
+    assert.ok(a, `example has no ${key}: block`);
+    assert.equal(b, a, `the skill template's ${key}: block has drifted from the example`);
+  });
+}
+
+test("neither workflow copy mentions a tier label that no longer exists", () => {
+  // There is no add/remove-label step in action.yml. `issues: write` is still
+  // required — for PR comments and the /orcacode-review reaction — so the
+  // permission stays and only its justification was wrong.
+  for (const [name, yaml] of [["example", EXAMPLE], ["skill template", TEMPLATE]]) {
+    assert.doesNotMatch(yaml, /tier state label|tier label/, `${name} still documents the tier label`);
+    assert.match(yaml, /issues: write/, `${name} dropped issues: write, which is still needed`);
+  }
+});
+
+test("the action no longer claims its token manages a tier label", () => {
+  const action = fs.readFileSync(new URL("../action.yml", import.meta.url), "utf8");
+  assert.doesNotMatch(action, /manage the tier label/);
+});

--- a/skills/setup-orca-code-review/assets/workflow.yml
+++ b/skills/setup-orca-code-review/assets/workflow.yml
@@ -22,7 +22,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  issues: write # tier state label + clean/fallback PR comments
+  issues: write # clean/fallback PR comments
 
 jobs:
   review:

--- a/skills/setup-orca-code-review/references/inputs.md
+++ b/skills/setup-orca-code-review/references/inputs.md
@@ -14,7 +14,7 @@ answering a question about behavior — do not guess a default.
 | Input | Default | What it does |
 | --- | --- | --- |
 | `orcarouter-url` | `https://api.orcarouter.ai/v1/chat/completions` | Chat-completions endpoint. Change only for a self-hosted gateway. |
-| `github-token` | `${{ github.token }}` | Fetches the PR head, posts comments, manages the tier label. |
+| `github-token` | `${{ github.token }}` | Fetches the PR head, posts review comments, and reacts to a `/orcacode-review` command. |
 | `brand` | `OrcaCode Review` | Name shown on PR comments. |
 | `router` | `orcarouter/code-review` | Router alias that owns model selection. The action names no models: it injects raw facts (`x-cr-prev-tier`, `x-cr-prev-p0p1`) and this router's DSL recipe maps them to a concrete model. |
 | `engine-version` | `1.3.13` | Pinned `@alibaba-group/open-code-review` version. Bump deliberately — later steps parse its JSON output shape. |
@@ -74,7 +74,7 @@ an error keeps the prior stage's findings and never aborts the review.
 | Input | Default | What it does |
 | --- | --- | --- |
 | `settings` | `true` | Fetch per-repo settings from the OrcaRouter dashboard at the start of each run. `false` skips the fetch and makes the workflow file authoritative. |
-| `report` | `true` | Send a per-run summary — repo, PR number, head SHA, tier, P0/P1/P2 counts, gate result, engine version. **Never code or finding text.** |
+| `report` | `true` | Send a per-run summary — repo, PR number, head SHA, tier, P0/P1/P2 counts, gate result, engine version. `tier` is always `standard` since the cascade was retired; the field is kept so the payload shape does not churn. **Never code or finding text.** |
 | `meter` | `true` | Record per-call token accounting and print a totals table in the job log. Local only; nothing is uploaded. |
 
 ### Precedence between the dashboard and this file
@@ -102,4 +102,4 @@ and only apply when `settings` is `true`.
 | `exhaustive` | on / off | Extra engine passes over the same diff, deduped. Costs more. |
 | `quiet` | on / off | Mutes P2 at posting time. The gate and the run report still see true counts. |
 | `rubric` | free text | Server-side rubric override for the review prompt. |
-| Models | per tier | Which model runs each tier. The action never names a model. |
+| Model | one | Which model runs the review. The action never names a model — the router resolves it. |


### PR DESCRIPTION
There is **no add- or remove-label step anywhere in `action.yml`**. Three files still described one — and the one that mattered most is the copy written into every user's repo.

## What happened

#28 retired the review cascade and updated `workflows/orca-code-review.yml`. But the skill keeps its **own copy** of that workflow in `assets/`, because that's the file it writes into a user's repo. The example got fixed; the template users actually receive did not.

```diff
  workflows/orca-code-review.yml              (fixed by #28)
- issues: write # tier state label + clean/fallback PR comments
+ issues: write # clean/fallback PR comments

  skills/.../assets/workflow.yml              (missed — this is the one users get)
- issues: write # tier state label + clean/fallback PR comments
```

## Fixed

| File | Was | Now |
| --- | --- | --- |
| `skills/.../assets/workflow.yml` | `# tier state label + clean/fallback PR comments` | matches the example |
| `references/inputs.md` — `github-token` | "manages the tier label" | "posts review comments, and reacts to a `/orcacode-review` command" |
| `references/inputs.md` — models | `Models \| per tier` | `Model \| one` |
| `action.yml` | "manage the tier label" | the source those two were copied from |

## `issues: write` stays

It is still required — just not for the reason the comment gave. It covers PR comments and the emoji reaction on a `/orcacode-review` command:

```
repos/$REPO/issues/comments/$COMMENT_ID/reactions
```

Only the justification was wrong, so only the justification changed.

## Left alone, because still true

- **`x-cr-prev-tier`** is still injected by the fact proxy. `action.yml`'s own header says the facts and rule shape are kept deliberately, so a future size-based routing policy needs no Action change.
- **`tier` in the run report** is still sent — but it is hardcoded `standard`. `inputs.md` now says so, otherwise a reader assumes it varies.

## Five tests close the gap

The root cause is two copies of one file. So the tests compare them: comment-stripped, the example and the skill template must agree on `permissions:`, `on:` and `concurrency:`, and neither may mention a tier label.

Verified by reverting the fix — `neither workflow copy mentions a tier label` goes red.

398 passing. 1.3.1: docs-only, but `skills/` ships in the npm package, so users keep receiving the wrong comment until it is published.