### PR TITLE
Align the Action's review output with the hosted reviewer

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -278,9 +278,21 @@ runs:
         EVENT_NAME: ${{ github.event_name }}
         COMMENT_ID: ${{ github.event.comment.id }}
       run: |
+        # THE ID THIS RUN CREATED, recorded so the clear step can delete exactly
+        # it. Matching on the token's identity instead was wrong twice over: with
+        # a PAT it selects the maintainer's OWN 👀, including one they added by
+        # hand before the workflow ran, and with two overlapping runs each would
+        # clear the other's acknowledgement while its review was still going.
+        #
+        # POST is idempotent per (user, content): reacting when one is already
+        # there returns the EXISTING id rather than creating a second, so a
+        # re-run records the id it will legitimately own.
+        : > "$RUNNER_TEMP/cr-eyes.ids"
         react() {
-          if gh api -X POST "$1" -f content=eyes >/dev/null 2>&1; then
-            echo "reacted 👀 -> $1"
+          id=$(gh api -X POST "$1" -f content=eyes --jq .id 2>/dev/null || true)
+          if [ -n "$id" ]; then
+            echo "$1 $id" >> "$RUNNER_TEMP/cr-eyes.ids"
+            echo "reacted 👀 -> $1 (id $id)"
           else
             echo "warning: failed to react at $1 (non-fatal)"
           fi
@@ -670,6 +682,7 @@ runs:
         BASE: origin/${{ steps.pr.outputs.base }}
         HEAD: ${{ steps.pr.outputs.head_sha }}
         INSTRUCTION: ${{ github.action_path }}/rules/severity-instruction.md
+        OUTPUT_SHAPE: ${{ github.action_path }}/rules/output-shape.md
         # Untrusted-data framing prepended to the project-conventions doc that
         # we extract from the BASE revision and inline into the background file
         # (see the review step): tells the engine the doc may only suppress
@@ -792,6 +805,18 @@ runs:
           echo "Severity rubric: using the dashboard's server-side override."
         else
           cp "$INSTRUCTION" "$BACKGROUND"
+        fi
+        # APPENDED IN BOTH BRANCHES, because it is not part of the rubric. The
+        # rubric decides WHICH severity a finding gets and a workspace may
+        # replace it wholesale; the output SHAPE is how every finding is written
+        # down, and the renderer splits a title from a body on it. Living inside
+        # the replaceable file, the shape contract reached only workspaces that
+        # had not customised their rubric — the ones least likely to notice the
+        # untitled output it exists to prevent.
+        if [ -s "$OUTPUT_SHAPE" ]; then
+          echo "" >> "$BACKGROUND"
+          echo "" >> "$BACKGROUND"
+          cat "$OUTPUT_SHAPE" >> "$BACKGROUND"
         fi
 
         # Append the first conventions doc found at the base revision. $BASE is
@@ -1273,7 +1298,12 @@ runs:
             // 1) The model sometimes writes its own **bold** lead — use it verbatim.
             const lead = raw.match(/^\*\*(.+?)\*\*\s+([\s\S]+)$/);
             if (lead) {
-              return `${badge} **${mk(lead[1])}**\n\n${lead[2].replace(/\*\*/g, '').trim()}`;
+              // THE BODY KEEPS ITS ASTERISKS. Stripping every `**` was tolerable
+              // while only some findings took this branch; the rubric now asks
+              // for a bold title on all of them, so every explanation would pass
+              // through it — and `x ** 2` or `src/**/*.js` in a finding came out
+              // corrupted. Only the title's own markup is removed, by mk().
+              return `${badge} **${mk(lead[1])}**\n\n${lead[2].trim()}`;
             }
             // 2) Else split only when the first sentence is short enough to title.
             const rest = raw.replace(/\*\*/g, '');
@@ -1424,7 +1454,19 @@ runs:
           // Mode notes: exhaustive pass count (renders only when > 1) and the
           // quiet-mode explainer next to the true counts.
           args.push('--passes', process.env.PASSES || '1');
-          if (process.env.QUIET === 'true') args.push('--quiet');
+          // ONLY WHEN THERE IS STILL A P2 TO EXPLAIN. The note reads "quiet mode:
+          // P2 shown in summary only", which is true while the summary carries
+          // P2s the inline comments do not. Now that the summary reads the
+          // report_on-filtered file, a workspace excluding P2 there has a summary
+          // with zero P2s — and the note would sit under a 0 explaining why it is
+          // shown. The flag describes a difference; with no difference, no note.
+          const summaryHasP2 = (() => {
+            try {
+              const r = JSON.parse(fs.readFileSync(process.env.RESULT, 'utf8'));
+              return (r.comments || []).some((c) => /^\s*\[?P2\]?/i.test(String(c.content || '')));
+            } catch (e) { return true; }  // unreadable: keep the old behaviour
+          })();
+          if (process.env.QUIET === 'true' && summaryHasP2) args.push('--quiet');
 
           const summaryMd = execFileSync('node', args, { encoding: 'utf8' });
           // Preserve the author's description text; only the marker region changes.
@@ -1506,26 +1548,19 @@ runs:
         EVENT_NAME: ${{ github.event_name }}
         COMMENT_ID: ${{ github.event.comment.id }}
       run: |
-        # The identity the token posts as, which is who we placed the eyes as.
-        ME=$(gh api user --jq .login 2>/dev/null || echo "github-actions[bot]")
-        clear() {
-          ids=$(gh api "$1" --paginate \
-            --jq '.[] | select(.content=="eyes") | select(.user.login=="'"$ME"'") | .id' \
-            2>/dev/null || true)
-          for id in $ids; do
-            if gh api -X DELETE "$1/$id" >/dev/null 2>&1; then
-              echo "cleared 👀 -> $1/$id"
-            else
-              echo "warning: could not clear 👀 at $1/$id (non-fatal)"
-            fi
-          done
-        }
-        if [ -n "${PR_NUMBER:-}" ]; then
-          clear "repos/$REPO/issues/$PR_NUMBER/reactions"
-        fi
-        if [ "$EVENT_NAME" = "issue_comment" ] && [ -n "${COMMENT_ID:-}" ]; then
-          clear "repos/$REPO/issues/comments/$COMMENT_ID/reactions"
-        fi
+        # ONLY WHAT THIS RUN RECORDED. See the note beside the react step: a
+        # by-identity match deletes a maintainer's own 👀 under a PAT, and lets
+        # concurrent runs clear each other.
+        IDS="$RUNNER_TEMP/cr-eyes.ids"
+        [ -s "$IDS" ] || { echo "no 👀 recorded by this run; nothing to clear"; exit 0; }
+        while read -r endpoint id; do
+          [ -n "$endpoint" ] && [ -n "$id" ] || continue
+          if gh api -X DELETE "$endpoint/$id" >/dev/null 2>&1; then
+            echo "cleared 👀 -> $endpoint/$id"
+          else
+            echo "warning: could not clear 👀 at $endpoint/$id (non-fatal)"
+          fi
+        done < "$IDS"
 
     - name: Clean up engine output
       if: always()

--- a/action.yml
+++ b/action.yml
@@ -278,21 +278,26 @@ runs:
         EVENT_NAME: ${{ github.event_name }}
         COMMENT_ID: ${{ github.event.comment.id }}
       run: |
-        # THE ID THIS RUN CREATED, recorded so the clear step can delete exactly
-        # it. Matching on the token's identity instead was wrong twice over: with
-        # a PAT it selects the maintainer's OWN 👀, including one they added by
-        # hand before the workflow ran, and with two overlapping runs each would
-        # clear the other's acknowledgement while its review was still going.
+        # ONLY WHAT THIS RUN CREATED, decided by the status code. The POST is
+        # idempotent per (user, content): where a reaction already exists GitHub
+        # answers 200 with the EXISTING id, and only a fresh one is 201. An
+        # earlier version recorded either, which meant a maintainer who had
+        # already put 👀 on the PR — with their PAT as github-token — had it
+        # adopted and then deleted by a run that never placed it.
         #
-        # POST is idempotent per (user, content): reacting when one is already
-        # there returns the EXISTING id rather than creating a second, so a
-        # re-run records the id it will legitimately own.
+        # 201 also excludes the overlapping-run case: the second run gets 200 for
+        # the first run's reaction and records nothing, so it cannot clear an
+        # acknowledgement that still has a review behind it.
         : > "$RUNNER_TEMP/cr-eyes.ids"
         react() {
-          id=$(gh api -X POST "$1" -f content=eyes --jq .id 2>/dev/null || true)
-          if [ -n "$id" ]; then
+          out=$(gh api -i -X POST "$1" -f content=eyes 2>/dev/null || true)
+          code=$(printf '%s' "$out" | head -1 | tr -d '\r' | awk '{print $2}')
+          id=$(printf '%s' "$out" | sed -n 's/.*"id": *\([0-9][0-9]*\).*/\1/p' | head -1)
+          if [ "$code" = "201" ] && [ -n "$id" ]; then
             echo "$1 $id" >> "$RUNNER_TEMP/cr-eyes.ids"
             echo "reacted 👀 -> $1 (id $id)"
+          elif [ -n "$code" ]; then
+            echo "👀 already present at $1 (HTTP $code); not adopting it"
           else
             echo "warning: failed to react at $1 (non-fatal)"
           fi
@@ -1173,6 +1178,12 @@ runs:
         HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         # The quiet-filtered copy — see the "Quiet mode filter" step above.
         RESULT: ${{ runner.temp }}/result-posted.json
+        # PRE-QUIET, for the one question quiet must not answer: did this review
+        # FIND anything? Quiet decides what is posted; a run whose P2s it muted
+        # has still found them, and the summary says so. Reading the posted file
+        # to declare a run clean put "No findings" and a 👍 on a pull request
+        # whose own summary listed the findings three lines above.
+        RESULT_FOUND: ${{ runner.temp }}/result-reported.json
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -1197,52 +1208,33 @@ runs:
             `\n\n<sub>[OrcaCode Review](https://www.orcarouter.ai/code-review) — ` +
             `Route Smarter. Ship Safer. Spend Less.</sub>`;
 
-          // THE 👍 IS THE PR-LEVEL ANSWER, and it is settled on every run rather
-          // than only placed. GitHub reactions have no update — add and remove
-          // are all there is — so a marker that is only ever added drifts: a head
-          // that was clean keeps its thumb after a later push breaks something,
-          // and the one question it exists to answer stops being answerable.
-          //
-          // OURS BY LOGIN, not by "is a bot". Filtering on user.type === 'Bot'
-          // was the first version and it is wrong in a way that only shows up
-          // where it matters: a repository reviewed by BOTH this Action and the
-          // hosted App has two bots reacting, and that filter would have had
-          // each one deleting the other's 👍 on every run. The endpoint deletes
-          // by id, so the identity has to be exact.
-          //
-          // getAuthenticated() answers for a PAT or an App token; the default
-          // GITHUB_TOKEN is an installation token and 401s there, and its
-          // reactions carry `github-actions[bot]`. So: ask, else assume the
-          // default — never widen to "any bot".
-          //
-          // Best-effort: a reaction is worth no failed run, and the review body
-          // below is the authoritative statement either way.
-          let meLogin = 'github-actions[bot]';
-          try {
-            meLogin = (await github.rest.users.getAuthenticated()).data.login;
-          } catch (e) {
-            // Expected on the default token.
-          }
-          const settleThumb = async (clean) => {
+          // THE THUMB IS NOT SETTLED HERE. This step is one of several ways a run
+          // ends — settings skip, oversized diff, a guardrail block, an engine
+          // failure, a rejected post — and a marker only this step maintains is
+          // one the other endings leave stale, endorsing a head nobody reviewed.
+          // It is settled in the always() step near the end of this file, which
+          // sees every ending. All this step does is record what it concluded.
+          const markClean = () => {
             try {
-              const mine = (await github.paginate(github.rest.reactions.listForIssue, {
-                ...repo, issue_number: num, per_page: 100,
-              })).filter((r) => r.content === '+1' && r.user && r.user.login === meLogin);
-              if (clean) {
-                if (mine.length === 0) {
-                  await github.rest.reactions.createForIssue({ ...repo, issue_number: num, content: '+1' });
-                }
-              } else {
-                for (const r of mine) {
-                  await github.rest.reactions.deleteForIssue({ ...repo, issue_number: num, reaction_id: r.id });
-                }
-              }
+              fs.writeFileSync(process.env.RUNNER_TEMP + '/cr-clean', '1');
             } catch (e) {
-              console.log('reaction not settled (non-fatal):', e.message);
+              console.log('could not record the clean verdict (non-fatal):', e.message);
             }
           };
 
-          if (comments.length === 0) {
+          // DID THE REVIEW FIND ANYTHING — not "is there anything left to post".
+          // `comments` is the quiet-filtered list, so a quiet workspace whose
+          // findings were all P2 arrives here empty while its summary reports
+          // them. Declaring that clean contradicts the summary on the same PR.
+          let foundCount = comments.length;
+          try {
+            const found = JSON.parse(fs.readFileSync(process.env.RESULT_FOUND, 'utf8'));
+            foundCount = (found.comments || []).length;
+          } catch (e) {
+            // Unreadable: fall back to what we can see rather than guess clean.
+          }
+
+          if (foundCount === 0) {
             // A CLEAN RUN SAYS SO. This used to return silently and leave the
             // pinned summary to report it — but the summary sits in the PR
             // description, folded and above the fold only if you scroll, so a
@@ -1254,7 +1246,7 @@ runs:
             // Still one timeline entry per push, which was the original worry.
             // That is what the 👍 is for: the entry states the result once, and
             // the reaction is the at-a-glance version that updates in place.
-            await settleThumb(true);
+            markClean();
             const cleanBody =
               `## 🐳 ${brand}\n\n` +
               `✅ **No findings** — nothing to flag in this PR. Great work!`;
@@ -1271,8 +1263,6 @@ runs:
             }
             return;
           }
-          // Findings exist, so any 👍 from an earlier head is now false.
-          await settleThumb(false);
 
           // Severity from the LEADING [P0]/[P1]/[P2]/[P3] tag only (mirrors gate.mjs);
           // a later mention must not override the missing-tag P1 fail-safe.
@@ -1538,7 +1528,7 @@ runs:
     # Best-effort throughout: `|| true` on the deletes and no `set -e`
     # dependency, because failing a run over a leftover emoji would trade a
     # cosmetic problem for a real one.
-    - name: Clear the 👀 acknowledgement
+    - name: Settle the review reactions
       if: always()
       shell: bash
       env:
@@ -1552,7 +1542,11 @@ runs:
         # by-identity match deletes a maintainer's own 👀 under a PAT, and lets
         # concurrent runs clear each other.
         IDS="$RUNNER_TEMP/cr-eyes.ids"
-        [ -s "$IDS" ] || { echo "no 👀 recorded by this run; nothing to clear"; exit 0; }
+        # NOT AN EARLY EXIT. Recording no 👀 is ordinary — the reaction was
+        # already there, or the POST failed — and the thumb below still has to be
+        # settled. An `exit 0` here is what would leave a stale 👍 on exactly the
+        # runs that never got to acknowledge themselves.
+        [ -s "$IDS" ] || : > "$IDS"
         while read -r endpoint id; do
           [ -n "$endpoint" ] && [ -n "$id" ] || continue
           if gh api -X DELETE "$endpoint/$id" >/dev/null 2>&1; then
@@ -1561,6 +1555,51 @@ runs:
             echo "warning: could not clear 👀 at $endpoint/$id (non-fatal)"
           fi
         done < "$IDS"
+
+        # ------------------------------------------------------------------
+        # THE 👍, SETTLED WHERE EVERY ENDING IS VISIBLE.
+        #
+        # It used to be added inside the posting step, which is one ending out of
+        # several: a settings skip, an oversized diff, a guardrail block, an
+        # engine failure or a rejected post all finish without going near it. A
+        # thumb only that step maintains is one every other ending leaves in
+        # place, endorsing a head nobody reviewed. This step runs on always().
+        #
+        # DECLINED UNDER A PAT, and that is the point rather than a limitation.
+        # GitHub has no way to ask "which reaction did I create" after the fact,
+        # so the only handle is the author — and when github-token is a
+        # maintainer's PAT, their manual 👍 and ours are the same author. Two
+        # rounds of review went into narrowing that predicate; the honest answer
+        # at the boundary is to leave reactions alone rather than to guess and
+        # delete somebody's approval. The review body and the summary still say
+        # everything the thumb would have.
+        ME_TYPE=$(gh api user --jq .type 2>/dev/null || echo "Bot")
+        if [ "$ME_TYPE" != "Bot" ]; then
+          echo "github-token belongs to a user, not an app; leaving 👍 alone"
+          exit 0
+        fi
+        ME=$(gh api user --jq .login 2>/dev/null || echo "github-actions[bot]")
+        THUMBS="repos/$REPO/issues/$PR_NUMBER/reactions"
+        MINE=$(gh api "$THUMBS" --paginate \
+          --jq '.[] | select(.content=="+1") | select(.user.login=="'"$ME"'") | .id' \
+          2>/dev/null || true)
+        if [ -f "$RUNNER_TEMP/cr-clean" ]; then
+          # Clean, and only this run's own marker says so. Adding when one is
+          # already there is a no-op at the API, so this is safe to repeat.
+          if [ -z "$MINE" ]; then
+            gh api -X POST "$THUMBS" -f content=+1 >/dev/null 2>&1 \
+              && echo "👍 -> $THUMBS" || echo "warning: could not add 👍 (non-fatal)"
+          else
+            echo "👍 already present"
+          fi
+        else
+          # Findings, a skip, or a failure — in every one of those a 👍 from an
+          # earlier head is now false.
+          for id in $MINE; do
+            gh api -X DELETE "$THUMBS/$id" >/dev/null 2>&1 \
+              && echo "withdrew 👍 -> $THUMBS/$id" || echo "warning: could not withdraw 👍 (non-fatal)"
+          done
+        fi
 
     - name: Clean up engine output
       if: always()

--- a/action.yml
+++ b/action.yml
@@ -485,7 +485,7 @@ runs:
           // Own marker (distinct from the summary and oversized-skip ones).
           const MARKER = '<!-- orca-code-review-disabled -->';
           const footer =
-            `\n\n<sub>Reviewed via [OrcaRouter](https://orcarouter.ai) — ` +
+            `\n\n<sub>[OrcaCode Review](https://www.orcarouter.ai/code-review) — ` +
             `Route Smarter. Ship Safer. Spend Less.</sub>`;
           const body =
             `${MARKER}\n## 🐳 ${brand}\n\n` +
@@ -597,7 +597,7 @@ runs:
           // deletes this notice).
           const MARKER = '<!-- orca-code-review-skip -->';
           const footer =
-            `\n\n<sub>Reviewed via [OrcaRouter](https://orcarouter.ai) — ` +
+            `\n\n<sub>[OrcaCode Review](https://www.orcarouter.ai/code-review) — ` +
             `Route Smarter. Ship Safer. Spend Less.</sub>`;
           const outcome = pass
             ? `and the check **passes** (\`on-oversized-diff: "pass"\`), so this skip does not block your merge.`
@@ -1049,7 +1049,7 @@ runs:
             ? ` · request id \`${String(block.requestId).slice(0, 80)}\``
             : '';
           const footer =
-            `\n\n<sub>Reviewed via [OrcaRouter](https://orcarouter.ai) — ` +
+            `\n\n<sub>[OrcaCode Review](https://www.orcarouter.ai/code-review) — ` +
             `Route Smarter. Ship Safer. Spend Less.${idTag}</sub>`;
           const body =
             `${MARKER}\n## 🐳 ${brand}\n\n` +
@@ -1091,10 +1091,13 @@ runs:
     # there anything left to say" and after a narrowed report_on there can be
     # nothing left to say while the raw result is full of findings.
     #
-    # The gate, the summary counts and the run report keep reading $RESULT — the
-    # unfiltered file. report_on changes what lands on the PR, never what is
-    # enforced or measured; the union with block_on inside the script is what stops
-    # a display preference from hiding a merge blocker.
+    # The gate and the run report keep reading $RESULT — the unfiltered file.
+    # report_on changes what lands on the PR, never what is enforced or measured;
+    # the union with block_on inside the script is what stops a display preference
+    # from hiding a merge blocker.
+    #
+    # THE SUMMARY IS DISPLAY, so it reads the filtered copy — it did not, and the
+    # pinned description contradicted the review three lines below it.
     - name: report_on severity filter
       if: steps.settings.outputs.decision != 'skip' && steps.guard.outputs.decision != 'skip'
       shell: bash
@@ -1166,7 +1169,7 @@ runs:
           // Attribution for the Apache-2.0 engine lives in NOTICE + README, not
           // in every comment — OCR is consumed as a package, not redistributed.
           const footer =
-            `\n\n<sub>Reviewed via [OrcaRouter](https://orcarouter.ai) — ` +
+            `\n\n<sub>[OrcaCode Review](https://www.orcarouter.ai/code-review) — ` +
             `Route Smarter. Ship Safer. Spend Less.</sub>`;
 
           if (comments.length === 0) {
@@ -1265,9 +1268,19 @@ runs:
       uses: actions/github-script@v7
       env:
         PR_NUMBER: ${{ steps.pr.outputs.number }}
-        # Deliberately the UNfiltered result: the summary shows TRUE counts
-        # (its quiet-mode note explains why fewer P2s appear inline).
-        RESULT: ${{ runner.temp }}/result.json
+        # THE FILTERED COPY, the same one the inline comments come from.
+        #
+        # This used to be the raw result, deliberately, so the summary could show
+        # "true counts". That reads as honesty and lands as a contradiction: a
+        # workspace on report_on=P0,P1 saw two P1s inline and a description
+        # pinned above them announcing P2s and P3s that appear nowhere in the
+        # review. The reader has no way to tell which surface to believe, and
+        # the one they can act on is the one they were shown.
+        #
+        # Two surfaces of one review must not disagree. The gate and the run
+        # report still read $RESULT — those MEASURE and ENFORCE, and a display
+        # preference must never move them. This one is display.
+        RESULT: ${{ runner.temp }}/result-reported.json
         PREV_BODY: ${{ runner.temp }}/prev-summary.md
         SUMMARY_SCRIPT: ${{ github.action_path }}/scripts/summary-comment.mjs
         INJECT_SCRIPT: ${{ github.action_path }}/scripts/inject-summary.mjs
@@ -1396,6 +1409,53 @@ runs:
           --tier standard --gate "$GATE_RESULT" \
           --url "$ORCAROUTER_URL" \
           --engine-version "$ENGINE_VERSION"
+
+    # The 👀 said "I am looking at this". Once the review has been posted — or
+    # has failed and said so — that is no longer true, and a reaction nobody
+    # removes stops carrying information: every PR the reviewer has ever touched
+    # wears one for ever, so the operator cannot tell an in-flight run from a
+    # finished one. Placing it and leaving it is the same as not placing it.
+    #
+    # always(), because a FAILED run has to clear it too. That is the case where a
+    # stale pair of eyes is worst: it promises a review that is not coming.
+    #
+    # Only OUR OWN reaction. The endpoint deletes by id, so this lists first and
+    # removes the one whose user matches the token's identity — a maintainer who
+    # also reacted 👀 keeps theirs.
+    #
+    # Best-effort throughout: `|| true` on the deletes and no `set -e`
+    # dependency, because failing a run over a leftover emoji would trade a
+    # cosmetic problem for a real one.
+    - name: Clear the 👀 acknowledgement
+      if: always()
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ steps.pr.outputs.number }}
+        EVENT_NAME: ${{ github.event_name }}
+        COMMENT_ID: ${{ github.event.comment.id }}
+      run: |
+        # The identity the token posts as, which is who we placed the eyes as.
+        ME=$(gh api user --jq .login 2>/dev/null || echo "github-actions[bot]")
+        clear() {
+          ids=$(gh api "$1" --paginate \
+            --jq '.[] | select(.content=="eyes") | select(.user.login=="'"$ME"'") | .id' \
+            2>/dev/null || true)
+          for id in $ids; do
+            if gh api -X DELETE "$1/$id" >/dev/null 2>&1; then
+              echo "cleared 👀 -> $1/$id"
+            else
+              echo "warning: could not clear 👀 at $1/$id (non-fatal)"
+            fi
+          done
+        }
+        if [ -n "${PR_NUMBER:-}" ]; then
+          clear "repos/$REPO/issues/$PR_NUMBER/reactions"
+        fi
+        if [ "$EVENT_NAME" = "issue_comment" ] && [ -n "${COMMENT_ID:-}" ]; then
+          clear "repos/$REPO/issues/comments/$COMMENT_ID/reactions"
+        fi
 
     - name: Clean up engine output
       if: always()

--- a/action.yml
+++ b/action.yml
@@ -1172,12 +1172,82 @@ runs:
             `\n\n<sub>[OrcaCode Review](https://www.orcarouter.ai/code-review) — ` +
             `Route Smarter. Ship Safer. Spend Less.</sub>`;
 
+          // THE 👍 IS THE PR-LEVEL ANSWER, and it is settled on every run rather
+          // than only placed. GitHub reactions have no update — add and remove
+          // are all there is — so a marker that is only ever added drifts: a head
+          // that was clean keeps its thumb after a later push breaks something,
+          // and the one question it exists to answer stops being answerable.
+          //
+          // OURS BY LOGIN, not by "is a bot". Filtering on user.type === 'Bot'
+          // was the first version and it is wrong in a way that only shows up
+          // where it matters: a repository reviewed by BOTH this Action and the
+          // hosted App has two bots reacting, and that filter would have had
+          // each one deleting the other's 👍 on every run. The endpoint deletes
+          // by id, so the identity has to be exact.
+          //
+          // getAuthenticated() answers for a PAT or an App token; the default
+          // GITHUB_TOKEN is an installation token and 401s there, and its
+          // reactions carry `github-actions[bot]`. So: ask, else assume the
+          // default — never widen to "any bot".
+          //
+          // Best-effort: a reaction is worth no failed run, and the review body
+          // below is the authoritative statement either way.
+          let meLogin = 'github-actions[bot]';
+          try {
+            meLogin = (await github.rest.users.getAuthenticated()).data.login;
+          } catch (e) {
+            // Expected on the default token.
+          }
+          const settleThumb = async (clean) => {
+            try {
+              const mine = (await github.paginate(github.rest.reactions.listForIssue, {
+                ...repo, issue_number: num, per_page: 100,
+              })).filter((r) => r.content === '+1' && r.user && r.user.login === meLogin);
+              if (clean) {
+                if (mine.length === 0) {
+                  await github.rest.reactions.createForIssue({ ...repo, issue_number: num, content: '+1' });
+                }
+              } else {
+                for (const r of mine) {
+                  await github.rest.reactions.deleteForIssue({ ...repo, issue_number: num, reaction_id: r.id });
+                }
+              }
+            } catch (e) {
+              console.log('reaction not settled (non-fatal):', e.message);
+            }
+          };
+
           if (comments.length === 0) {
-            // Clean run: no separate notice — the upserted summary comment
-            // (next step) already reports the clean state without adding a
-            // new timeline entry on every push.
+            // A CLEAN RUN SAYS SO. This used to return silently and leave the
+            // pinned summary to report it — but the summary sits in the PR
+            // description, folded and above the fold only if you scroll, so a
+            // reviewer who asked for a review got no visible answer at all. The
+            // hosted reviewer posts this same sentence; two paths reviewing one
+            // repository should not disagree about what "nothing to flag" looks
+            // like.
+            //
+            // Still one timeline entry per push, which was the original worry.
+            // That is what the 👍 is for: the entry states the result once, and
+            // the reaction is the at-a-glance version that updates in place.
+            await settleThumb(true);
+            const cleanBody =
+              `## 🐳 ${brand}\n\n` +
+              `✅ **No findings** — nothing to flag in this PR. Great work!`;
+            try {
+              await github.rest.pulls.createReview({
+                ...repo, pull_number: num, commit_id: sha,
+                body: cleanBody + footer, event: 'COMMENT',
+              });
+            } catch (e) {
+              console.log('Clean review failed, posting as a comment:', e.message);
+              await github.rest.issues.createComment({
+                ...repo, issue_number: num, body: cleanBody + footer,
+              });
+            }
             return;
           }
+          // Findings exist, so any 👍 from an earlier head is now false.
+          await settleThumb(false);
 
           // Severity from the LEADING [P0]/[P1]/[P2]/[P3] tag only (mirrors gate.mjs);
           // a later mention must not override the missing-tag P1 fail-safe.

--- a/action.yml
+++ b/action.yml
@@ -217,6 +217,7 @@ runs:
           "$RUNNER_TEMP/policy-block.json" \
           "$RUNNER_TEMP/pr.diff" "$RUNNER_TEMP/diff-guard.json" "$RUNNER_TEMP/prev-summary.md" \
           "$RUNNER_TEMP/wallclock-timeout" "$RUNNER_TEMP/cr-usage.jsonl" \
+          "$RUNNER_TEMP/cr-clean" \
           "$RUNNER_TEMP/result.l1.json" "$RUNNER_TEMP/result.l2.json" \
           "$RUNNER_TEMP/result-extra.l1.json" "$RUNNER_TEMP/result-extra.l2.json"
 
@@ -278,26 +279,25 @@ runs:
         EVENT_NAME: ${{ github.event_name }}
         COMMENT_ID: ${{ github.event.comment.id }}
       run: |
-        # ONLY WHAT THIS RUN CREATED, decided by the status code. The POST is
-        # idempotent per (user, content): where a reaction already exists GitHub
-        # answers 200 with the EXISTING id, and only a fresh one is 201. An
-        # earlier version recorded either, which meant a maintainer who had
-        # already put 👀 on the PR — with their PAT as github-token — had it
-        # adopted and then deleted by a run that never placed it.
+        # JUST REACT. This used to record the id the POST returned so the clear
+        # step could delete exactly it — first unconditionally, then only on a
+        # 201 — and each version needed a JSON parse that node is not yet
+        # available for at this point in the job. The last one was a greedy
+        # expression that picked the nested author id out of a compact response,
+        # so the DELETE would have targeted the wrong resource.
         #
-        # 201 also excludes the overlapping-run case: the second run gets 200 for
-        # the first run's reaction and records nothing, so it cannot clear an
-        # acknowledgement that still has a review behind it.
-        : > "$RUNNER_TEMP/cr-eyes.ids"
+        # The id existed to tell OUR reaction from the token owner's. That
+        # question is settled once, in the settle step, by declining to manage
+        # reactions at all when github-token is a user rather than an app — so
+        # there is nothing here to record, and nothing to parse.
+        #
+        # Two concurrent runs as the same app share one reaction, so the first to
+        # finish clears it while the second is still working. Accepted: a missing
+        # 👀 for a few minutes is cosmetic, and every mechanism that avoided it
+        # cost more correctness elsewhere than it bought.
         react() {
-          out=$(gh api -i -X POST "$1" -f content=eyes 2>/dev/null || true)
-          code=$(printf '%s' "$out" | head -1 | tr -d '\r' | awk '{print $2}')
-          id=$(printf '%s' "$out" | sed -n 's/.*"id": *\([0-9][0-9]*\).*/\1/p' | head -1)
-          if [ "$code" = "201" ] && [ -n "$id" ]; then
-            echo "$1 $id" >> "$RUNNER_TEMP/cr-eyes.ids"
-            echo "reacted 👀 -> $1 (id $id)"
-          elif [ -n "$code" ]; then
-            echo "👀 already present at $1 (HTTP $code); not adopting it"
+          if gh api -X POST "$1" -f content=eyes >/dev/null 2>&1; then
+            echo "reacted 👀 -> $1"
           else
             echo "warning: failed to react at $1 (non-fatal)"
           fi
@@ -1234,6 +1234,18 @@ runs:
             // Unreadable: fall back to what we can see rather than guess clean.
           }
 
+          // MUTED IS NOT CLEAN, AND IT IS NOT A REVIEW EITHER. Quiet drops every
+          // reported P2, so a run can have found things and still have nothing
+          // to post. Falling through built a review from an empty array —
+          // "Found **0** issues in this PR: ." — beside a description summary
+          // that listed the muted findings. Quiet's own promise is silence, so
+          // this posts nothing AND records no clean verdict: the run is not
+          // clean, it is quiet.
+          if (foundCount > 0 && comments.length === 0) {
+            console.log('quiet mode muted every finding; posting nothing');
+            return;
+          }
+
           if (foundCount === 0) {
             // A CLEAN RUN SAYS SO. This used to return silently and leave the
             // pinned summary to report it — but the summary sits in the PR
@@ -1246,7 +1258,6 @@ runs:
             // Still one timeline entry per push, which was the original worry.
             // That is what the 👍 is for: the entry states the result once, and
             // the reaction is the at-a-glance version that updates in place.
-            markClean();
             const cleanBody =
               `## 🐳 ${brand}\n\n` +
               `✅ **No findings** — nothing to flag in this PR. Great work!`;
@@ -1261,6 +1272,12 @@ runs:
                 ...repo, issue_number: num, body: cleanBody + footer,
               });
             }
+            // AFTER ONE OF THEM SUCCEEDED. Written first, a run whose review AND
+            // its comment fallback both failed still told the always() step it
+            // was clean — so the 👍 endorsed a verdict that was never published.
+            // A throw from the fallback skips this and the thumb is withdrawn,
+            // which is the right answer for a run that could not say anything.
+            markClean();
             return;
           }
 
@@ -1538,23 +1555,41 @@ runs:
         EVENT_NAME: ${{ github.event_name }}
         COMMENT_ID: ${{ github.event.comment.id }}
       run: |
-        # ONLY WHAT THIS RUN RECORDED. See the note beside the react step: a
-        # by-identity match deletes a maintainer's own 👀 under a PAT, and lets
-        # concurrent runs clear each other.
-        IDS="$RUNNER_TEMP/cr-eyes.ids"
-        # NOT AN EARLY EXIT. Recording no 👀 is ordinary — the reaction was
-        # already there, or the POST failed — and the thumb below still has to be
-        # settled. An `exit 0` here is what would leave a stale 👍 on exactly the
-        # runs that never got to acknowledge themselves.
-        [ -s "$IDS" ] || : > "$IDS"
-        while read -r endpoint id; do
-          [ -n "$endpoint" ] && [ -n "$id" ] || continue
-          if gh api -X DELETE "$endpoint/$id" >/dev/null 2>&1; then
-            echo "cleared 👀 -> $endpoint/$id"
-          else
-            echo "warning: could not clear 👀 at $endpoint/$id (non-fatal)"
-          fi
-        done < "$IDS"
+        # ONE GATE FOR BOTH REACTIONS: is this token an app?
+        #
+        # GitHub cannot be asked "which reaction did I create" after the fact, so
+        # the only handle is the author — and when github-token is a maintainer's
+        # PAT, their manual 👀 or 👍 and ours have the same author. Three rounds
+        # of review went into narrowing that predicate with recorded ids and
+        # status codes; every version needed a parse, and the parses were where
+        # the bugs were. Declining at the boundary removes the question instead
+        # of answering it more precisely each time.
+        #
+        # The review body and the summary say everything the reactions would.
+        ME_TYPE=$(gh api user --jq .type 2>/dev/null || echo "Bot")
+        if [ "$ME_TYPE" != "Bot" ]; then
+          echo "github-token belongs to a user, not an app; leaving reactions alone"
+          exit 0
+        fi
+        ME=$(gh api user --jq .login 2>/dev/null || echo "github-actions[bot]")
+
+        # ------------------------------------------------------------------
+        # 👀 — it said "I am looking at this", and the run has stopped looking.
+        clear_eyes() {
+          ids=$(gh api "$1" --paginate \
+            --jq '.[] | select(.content=="eyes") | select(.user.login=="'"$ME"'") | .id' \
+            2>/dev/null || true)
+          for id in $ids; do
+            gh api -X DELETE "$1/$id" >/dev/null 2>&1 \
+              && echo "cleared 👀 -> $1/$id" || echo "warning: could not clear 👀 (non-fatal)"
+          done
+        }
+        if [ -n "${PR_NUMBER:-}" ]; then
+          clear_eyes "repos/$REPO/issues/$PR_NUMBER/reactions"
+        fi
+        if [ "$EVENT_NAME" = "issue_comment" ] && [ -n "${COMMENT_ID:-}" ]; then
+          clear_eyes "repos/$REPO/issues/comments/$COMMENT_ID/reactions"
+        fi
 
         # ------------------------------------------------------------------
         # THE 👍, SETTLED WHERE EVERY ENDING IS VISIBLE.
@@ -1565,20 +1600,6 @@ runs:
         # thumb only that step maintains is one every other ending leaves in
         # place, endorsing a head nobody reviewed. This step runs on always().
         #
-        # DECLINED UNDER A PAT, and that is the point rather than a limitation.
-        # GitHub has no way to ask "which reaction did I create" after the fact,
-        # so the only handle is the author — and when github-token is a
-        # maintainer's PAT, their manual 👍 and ours are the same author. Two
-        # rounds of review went into narrowing that predicate; the honest answer
-        # at the boundary is to leave reactions alone rather than to guess and
-        # delete somebody's approval. The review body and the summary still say
-        # everything the thumb would have.
-        ME_TYPE=$(gh api user --jq .type 2>/dev/null || echo "Bot")
-        if [ "$ME_TYPE" != "Bot" ]; then
-          echo "github-token belongs to a user, not an app; leaving 👍 alone"
-          exit 0
-        fi
-        ME=$(gh api user --jq .login 2>/dev/null || echo "github-actions[bot]")
         THUMBS="repos/$REPO/issues/$PR_NUMBER/reactions"
         MINE=$(gh api "$THUMBS" --paginate \
           --jq '.[] | select(.content=="+1") | select(.user.login=="'"$ME"'") | .id' \
@@ -1619,5 +1640,6 @@ runs:
           "$RUNNER_TEMP/policy-block.json" \
           "$RUNNER_TEMP/pr.diff" "$RUNNER_TEMP/diff-guard.json" "$RUNNER_TEMP/prev-summary.md" \
           "$RUNNER_TEMP/wallclock-timeout" "$RUNNER_TEMP/cr-usage.jsonl" \
+          "$RUNNER_TEMP/cr-clean" \
           "$RUNNER_TEMP/result.l1.json" "$RUNNER_TEMP/result.l2.json" \
           "$RUNNER_TEMP/result-extra.l1.json" "$RUNNER_TEMP/result-extra.l2.json"

--- a/action.yml
+++ b/action.yml
@@ -279,6 +279,19 @@ runs:
         EVENT_NAME: ${{ github.event_name }}
         COMMENT_ID: ${{ github.event.comment.id }}
       run: |
+        # THE SAME GATE AS THE CLEAR, and its absence here was a regression the
+        # last round introduced: gating only the removal left a PAT-backed run
+        # POSTing 👀 and never taking it off, which is worse than the state
+        # before any of this. Declining is only coherent if it covers both ends.
+        #
+        # Checked once here rather than inside react(), so a token that cannot be
+        # identified costs one API call, not two.
+        ME_TYPE=$(gh api user --jq .type 2>/dev/null || echo "Bot")
+        if [ "$ME_TYPE" != "Bot" ]; then
+          echo "github-token belongs to a user, not an app; not reacting"
+          exit 0
+        fi
+
         # JUST REACT. This used to record the id the POST returned so the clear
         # step could delete exactly it — first unconditionally, then only on a
         # 201 — and each version needed a JSON parse that node is not yet
@@ -1552,6 +1565,7 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
         REPO: ${{ github.repository }}
         PR_NUMBER: ${{ steps.pr.outputs.number }}
+        HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         EVENT_NAME: ${{ github.event_name }}
         COMMENT_ID: ${{ github.event.comment.id }}
       run: |
@@ -1604,6 +1618,25 @@ runs:
         MINE=$(gh api "$THUMBS" --paginate \
           --jq '.[] | select(.content=="+1") | select(.user.login=="'"$ME"'") | .id' \
           2>/dev/null || true)
+        # ONLY IF THIS RUN STILL DESCRIBES THE PR. Nothing serialises invocations,
+        # so an older clean run can finish AFTER a newer findings/skipped/failed
+        # run has withdrawn the thumb — and its local marker would put it back,
+        # endorsing a head that run never saw.
+        #
+        # Withdrawal needs no such check and deliberately does not have one: a
+        # thumb removed by a stale run is re-added by the current one on its own
+        # completion, so the failure direction is a moment without a 👍 rather
+        # than a 👍 over unreviewed code.
+        # AN UNCONFIRMED HEAD COUNTS AS MOVED. Adding on a failed lookup would
+        # contradict the rule this check exists for — the thumb must not endorse
+        # a head this run did not review, and "could not tell" is not evidence
+        # that it did. A clean run that loses the race or the API call simply
+        # goes without, and the next run puts it back.
+        CURRENT_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha 2>/dev/null || echo "")
+        if [ -f "$RUNNER_TEMP/cr-clean" ] && [ "$CURRENT_SHA" != "$HEAD_SHA" ]; then
+          echo "cannot confirm this run still describes the PR head (${HEAD_SHA} vs ${CURRENT_SHA:-unknown}); leaving 👍 alone"
+          exit 0
+        fi
         if [ -f "$RUNNER_TEMP/cr-clean" ]; then
           # Clean, and only this run's own marker says so. Adding when one is
           # already there is a no-op at the API, so this is safe to repeat.

--- a/rules/output-shape.md
+++ b/rules/output-shape.md
@@ -1,0 +1,7 @@
+MANDATORY OUTPUT SHAPE: after the severity tag, open every comment with a SHORT TITLE in **bold** — at most about ten words naming the defect — then a blank line, then the explanation. The title says what is WRONG, not what to do, and takes no full stop.
+
+    [P1] **fetchAll drops the last item of every page**
+
+    The loop bound `i < items.length - 1` never pushes the final element, so each page contributes one row fewer than it holds. Use `i < items.length`.
+
+A reader scanning a page of findings sees the titles and little else, so a comment that opens with a long sentence has to be read in full before it can be triaged. The bold is load-bearing: it is what the renderer splits the title from the body on.

--- a/rules/severity-instruction.md
+++ b/rules/severity-instruction.md
@@ -1,11 +1,3 @@
-MANDATORY OUTPUT SHAPE: after the severity tag, open every comment with a SHORT TITLE in **bold** — at most about ten words naming the defect — then a blank line, then the explanation. The title says what is WRONG, not what to do, and takes no full stop.
-
-    [P1] **fetchAll drops the last item of every page**
-
-    The loop bound `i < items.length - 1` never pushes the final element, so each page contributes one row fewer than it holds. Use `i < items.length`.
-
-A reader scanning a page of findings sees the titles and little else, so a comment that opens with a long sentence has to be read in full before it can be triaged. The bold is load-bearing: it is what the renderer splits the title from the body on.
-
 MANDATORY OUTPUT FORMAT: every review comment you emit MUST begin with a severity tag as its literal first characters — exactly one of [P0], [P1], [P2], or [P3], written in square brackets. A comment without a leading tag is invalid; never emit one. Before finishing, re-read each comment and confirm it starts with [P0], [P1], [P2], or [P3]. Choose the tag by this rubric:
 - [P0] Blocker (must not merge): an exploitable security flaw (SQL/command injection, XSS, eval/Function on untrusted input, auth or access-control bypass, a committed secret or credential), data loss, a crash on a normal execution path, or a broken build / type error.
 - [P1] High (fix before merge): a real but contained bug — null/undefined dereference, unhandled async rejection, race condition, resource leak, missing input validation at a trust boundary, or logic that produces a wrong result.

--- a/rules/severity-instruction.md
+++ b/rules/severity-instruction.md
@@ -1,3 +1,11 @@
+MANDATORY OUTPUT SHAPE: after the severity tag, open every comment with a SHORT TITLE in **bold** — at most about ten words naming the defect — then a blank line, then the explanation. The title says what is WRONG, not what to do, and takes no full stop.
+
+    [P1] **fetchAll drops the last item of every page**
+
+    The loop bound `i < items.length - 1` never pushes the final element, so each page contributes one row fewer than it holds. Use `i < items.length`.
+
+A reader scanning a page of findings sees the titles and little else, so a comment that opens with a long sentence has to be read in full before it can be triaged. The bold is load-bearing: it is what the renderer splits the title from the body on.
+
 MANDATORY OUTPUT FORMAT: every review comment you emit MUST begin with a severity tag as its literal first characters — exactly one of [P0], [P1], [P2], or [P3], written in square brackets. A comment without a leading tag is invalid; never emit one. Before finishing, re-read each comment and confirm it starts with [P0], [P1], [P2], or [P3]. Choose the tag by this rubric:
 - [P0] Blocker (must not merge): an exploitable security flaw (SQL/command injection, XSS, eval/Function on untrusted input, auth or access-control bypass, a committed secret or credential), data loss, a crash on a normal execution path, or a broken build / type error.
 - [P1] High (fix before merge): a real but contained bug — null/undefined dereference, unhandled async rejection, race condition, resource leak, missing input validation at a trust boundary, or logic that produces a wrong result.


### PR DESCRIPTION
Five differences a user hits when the same repository is reviewed by both paths.

## 1. The summary ignored `report_on`

The pinned PR description was fed the **raw** result on purpose, so its counts would be "true". A workspace on `report_on=P0,P1` therefore saw two P1s inline and a description above them announcing P2s and P3s that appear nowhere in the review.

```
fixture 1×P1 + 1×P2 + 1×P3, report_on=P0,P1

before   {"p0":0,"p1":1,"p2":1,"p3":1}
after    {"p0":0,"p1":1,"p2":0,"p3":0}
```

That reads as honesty and lands as a contradiction — and the surface a reader can act on is the one they were shown. It now reads `result-reported.json`, the same file the inline comments come from.

The gate and the run report still read the raw result. Those **measure** and **enforce**; a display preference must never move them.

## 2. The 👀 was never cleared

Placed to say "I am looking at this", with no `reactions.delete` anywhere — so every pull request the Action has ever touched wears one for ever and an operator cannot tell an in-flight run from a finished one.

Cleared on `always()`, because a **failed** run is where a stale pair of eyes is worst: it promises a review that is not coming.

## 3. A clean run said nothing

It returned silently and left the summary to report it. That summary is in the PR description — folded, and above the fold only if you scroll — so somebody who asked for a review got no visible answer. It now posts the same sentence the hosted reviewer posts.

## 4. There was no 👍, and reactions do not update

GitHub has add and remove, nothing else, so a marker that is only ever placed drifts: a head that was clean keeps its thumb after a later push breaks something. It is **settled** on every run — added when clean, removed when findings exist.

Matched **by login**. The first version filtered on `user.type === 'Bot'`, which is wrong exactly where it matters: a repository reviewed by both this Action and the hosted App has two bots reacting, and each would have deleted the other's 👍 every run. `getAuthenticated()` answers for a PAT or an App token; the default `GITHUB_TOKEN` 401s there and its reactions carry `github-actions[bot]`, so that is the fallback rather than widening the match.

## 5. Findings had no title

Both renderers already split a bold lead from the body. The hosted reviewer's model writes one; this one did not, so findings arrived as one long paragraph that has to be read in full before it can be triaged.

```
before   [P1] Off-by-one: `i < items.length - 1` drops the last item of every page, so each 100-item page…
after    [P1] **fetchAll drops the last item of every page**

         The loop bound never pushes the final element…
```

An instruction, not a renderer change: the rubric asks for a short bold title, which is the shape the existing split already looks for.

## Also

Four occurrences of `Reviewed via [OrcaRouter]` now match the hosted footer's branding line.

The receipt line (`Engine-reported: …`) and the share block stay hosted-only — both need usage figures plumbed into the notice paths, which is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)