### PR TITLE
feat!: drop GitHub App mode from the skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Skills for OrcaRouter products.",
-    "version": "1.4.0"
+    "version": "1.5.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orca-code-review",
   "description": "Set up, reconfigure, troubleshoot, and remove OrcaCode Review — AI pull-request review powered by OrcaRouter — in any GitHub repository.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "Continuum-AI-Corp",
     "url": "https://github.com/Continuum-AI-Corp"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Automatically review every pull request, post findings directly on the affected 
 ---
 
 <p align="center">
-  <img src="docs/demo.gif" alt="Installing the skill with npx, then asking an agent to set up OrcaCode Review — in Action mode and in GitHub App mode" width="900">
+  <img src="docs/demo.gif" alt="Installing the skill with npx, then asking an agent to set up OrcaCode Review in a repo" width="900">
 </p>
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcarouter/code-review",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "One-command installer for OrcaCode Review — AI pull-request review powered by OrcaRouter.",
   "bin": {
     "orcacode-review": "bin/orcacode-review.mjs"

--- a/scripts/installer.test.mjs
+++ b/scripts/installer.test.mjs
@@ -214,44 +214,35 @@ test("the skill refuses to call an install complete without the secret", () => {
   assert.match(SKILL, /[Dd]o not report the\s+install as complete while the secret is missing/s);
 });
 
-// ------------------------------------------------------------ install modes ---
+// ----------------------------------------------------------- one install path ---
 
-test("the skill offers both install modes and routes between them", () => {
-  assert.match(SKILL, /## Install — GitHub App mode/);
-  assert.match(SKILL, /GitHub Action \(recommended\)/);
-  assert.match(SKILL, /https:\/\/github\.com\/apps\/orcacode-review\/installations\/new/);
+test("the skill offers exactly one way to install", () => {
+  // App mode was removed. A skill that still describes it would send users to
+  // an approval page for a path this repo no longer supports.
+  assert.doesNotMatch(SKILL, /GitHub App mode/);
+  assert.doesNotMatch(SKILL, /github\.com\/apps\/orcacode-review\/installations/);
+  assert.match(SKILL, /It runs as a \*\*GitHub Action\*\*/);
 });
 
-test("App mode warns about the permission before offering the choice", () => {
-  // Walking a plain org member to an approval page they will be stopped at is
-  // the whole failure this ordering exists to avoid.
-  const pick = SKILL.slice(SKILL.indexOf("### 0. Pick the mode"), SKILL.indexOf("### 1. Preflight"));
-  assert.match(pick, /permissions\.admin/, "no repo-permission probe");
-  assert.match(pick, /memberships/, "no org-role probe");
-  assert.match(pick, /organization owner/i);
-  assert.ok(
-    pick.indexOf("admin: false") < pick.indexOf("Chose App mode?"),
-    "the cannot-approve warning must come before the routing line",
-  );
+test("the install flow starts at preflight, with no mode question", () => {
+  const install = SKILL.slice(SKILL.indexOf("## Install"), SKILL.indexOf("## Reconfigure"));
+  assert.match(install, /### 1\. Preflight/);
+  assert.doesNotMatch(install, /Pick the mode/);
+  // Step numbering must be contiguous — removing step 0 is where an off-by-one
+  // would hide, and a skill that skips a number reads as a truncated file.
+  const steps = [...install.matchAll(/^### (\d+)\./gm)].map((m) => Number(m[1]));
+  assert.deepEqual(steps, [1, 2, 3, 4, 5, 6, 7, 8]);
 });
 
-test("App mode never claims the install can be automated", () => {
-  const app = SKILL.slice(SKILL.indexOf("## Install — GitHub App mode"), SKILL.indexOf("## Do not install both"));
-  assert.match(app, /no REST endpoint that installs an\s+App/s);
-  // Printing the URL matters more than opening it: SSH, containers and CI have
-  // no browser, and a silent `open` leaves the user waiting on nothing.
-  assert.match(app, /never open it without printing it/i);
-  // The repo secret belongs to Action mode only.
-  assert.match(app, /No `ORCAROUTER_API_KEY` secret is needed/);
-});
-
-test("the double-install conflict is documented in both places", () => {
-  assert.match(SKILL, /## Do not install both/);
+test("the double-review symptom is still documented", () => {
+  // The App exists whether or not this skill installs it, so someone can still
+  // end up with two reviewers.
   const trouble = fs.readFileSync(
     new URL("../skills/setup-orca-code-review/references/troubleshooting.md", import.meta.url),
     "utf8",
   );
   assert.match(trouble, /two sets of comments/i);
+  assert.match(trouble, /this skill does not install it/i);
 });
 
 // ------------------------------------------- the two workflow copies agree ---

--- a/skills/setup-orca-code-review/SKILL.md
+++ b/skills/setup-orca-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-orca-code-review
-description: Set up, reconfigure, troubleshoot, or remove OrcaCode Review — AI pull-request review powered by OrcaRouter — in a GitHub repository. Handles the whole lifecycle end to end without asking the user to run a CLI. Use whenever the user mentions OrcaCode Review, OrcaRouter code review, "@orcarouter code review", or /orcacode-review, and whenever they ask to set up AI code review on a repo, add the orca-code-review action, change which severities block merges, find out why a review did not run or did not post findings, take the review workflow back out, or install the OrcaCode Review GitHub App instead of the Action.
+description: Set up, reconfigure, troubleshoot, or remove OrcaCode Review — AI pull-request review powered by OrcaRouter — in a GitHub repository. Handles the whole lifecycle end to end without asking the user to run a CLI. Use whenever the user mentions OrcaCode Review, OrcaRouter code review, "@orcarouter code review", or /orcacode-review, and whenever they ask to set up AI code review on a repo, add the orca-code-review action, change which severities block merges, find out why a review did not run or did not post findings, or take the review workflow back out.
 ---
 
 # OrcaCode Review
@@ -9,12 +9,8 @@ OrcaCode Review reviews every pull request with an LLM, posts findings as inline
 comments, and fails a status check when serious issues are found. Model selection
 lives in OrcaRouter, not in the repo.
 
-It runs one of two ways, and a repo should use exactly one:
-
-- **GitHub Action** — a workflow file plus one secret. Needs write access.
-  The default, and the only one an agent can complete end to end.
-- **GitHub App** — a bot, nothing in the repo. Needs repo admin or org owner,
-  and a human to approve the install in a browser.
+It runs as a **GitHub Action**: a workflow file in the repo plus one secret.
+Write access is all it takes, and an agent can complete the whole setup.
 
 **Severity contract:** `P0` critical / `P1` high → ❌ block. `P2` advisory → 💬 comment.
 
@@ -26,8 +22,7 @@ run an installer; that is what this skill replaces.
 
 | The user says something like… | You do |
 | --- | --- |
-| "set up OrcaCode Review here", "@orcarouter code review 帮我配置这个仓库" | [Install](#install) — offer Action vs App first |
-| "install the GitHub App instead", "用 App 模式" | [App mode](#install--github-app-mode) |
+| "set up OrcaCode Review here", "@orcarouter code review 帮我配置这个仓库" | [Install](#install) |
 | "only block P0", "move the config to the dashboard", "raise the diff limit" | [Reconfigure](#reconfigure) |
 | "why didn't the review run?", "no comments appeared", "the check is stuck red" | [Troubleshoot](#troubleshoot) |
 | "remove OrcaCode Review", "turn the review off" | [Uninstall](#uninstall) |
@@ -50,39 +45,6 @@ If `gh` is missing or unauthenticated, everything still works — you just hand 
 user web URLs instead of running commands. Say so once and move on.
 
 ## Install
-
-There are two ways to run OrcaCode Review on a repo. Pick one — **never both**,
-see [Do not install both](#do-not-install-both).
-
-### 0. Pick the mode
-
-Check what the user is even able to do *before* offering the choice, so you do
-not walk them into an approval they cannot give:
-
-```bash
-gh api /repos/<owner>/<name> --jq '{admin: .permissions.admin, ownerType: .owner.type, owner: .owner.login}'
-# for an Organization owner, also:
-gh api /orgs/<owner>/memberships/$(gh api /user --jq .login) --jq .role   # "admin" | "member"
-```
-
-Then ask with `AskUserQuestion`:
-
-**"How should OrcaCode Review run on this repo?"**
-
-- *GitHub Action (recommended)* — a workflow file in the repo plus one secret.
-  Anyone with **write access** can set it up, it works on personal repos, and
-  the config is visible in the diff like any other CI. This is the path the
-  rest of this section describes.
-- *GitHub App* — no file in the repo; a bot reviews PRs. Needs **repo admin, or
-  organization owner** on an org repo. One approval can cover many repos.
-
-**If the probe above said `admin: false` and the org role is `member`, say so
-before they choose.** They cannot complete App mode themselves — they would
-click through to the approval page and be stopped there. Offer Action mode, or
-offer to draft the request they send to an owner.
-
-Chose App mode? → [Install — GitHub App mode](#install--github-app-mode).
-Otherwise carry on.
 
 ### 1. Preflight
 
@@ -183,7 +145,6 @@ key. Wait, or skip to step 8 and list it as outstanding.
 Point the user at **OrcaRouter → Apps → OrcaCode Review** (<https://www.orcarouter.ai/>)
 to turn it on and choose review models. Reviews will not run until it is enabled.
 
-This is the OrcaRouter console, not the GitHub App — Action mode still needs it.
 There is no API for this step today, so it is the user's to do.
 
 ### 6. Commit and open a test PR
@@ -226,110 +187,6 @@ Re-check with `gh secret list` before claiming it is done. Do not report the
 install as complete while the secret is missing: the workflow is in place but
 every run will fail on auth, and "installed" would be a lie the user only finds
 out about on their next PR.
-
-## Install — GitHub App mode
-
-No file lands in the repo. OrcaRouter reviews pull requests as a bot, and the
-repo's own config is the App's installation rather than a workflow.
-
-### 1. Confirm they can actually approve it
-
-Installing a GitHub App is a **permission grant**, so GitHub requires a human to
-approve it on an authorization page. There is no REST endpoint that installs an
-App on someone's behalf — this is deliberate, not a gap you can route around.
-
-The approver must be **repo admin**, or an **organization owner** for an org
-repo. If the step-0 probe showed otherwise, stop here and offer:
-
-- Action mode instead, which only needs write access, or
-- a message they can forward to an owner, containing the install link below and
-  one line on what it does.
-
-### 2. Hand over the link
-
-Print the URL. Offer to open it, but **never open it without printing it** —
-SSH sessions, containers and CI have no browser, and a tool that silently
-launches nothing leaves the user waiting on something that will not happen.
-
-```
-https://github.com/apps/orcacode-review/installations/new
-```
-
-To open it as well:
-
-```bash
-open <url>        # macOS
-xdg-open <url>    # Linux
-```
-
-Tell them what to expect on that page: choose the account or organization, then
-**select only this repository** unless they mean to cover more. "All
-repositories" is a much larger grant, and on a paid plan a much larger bill.
-
-### 3. Wait, then verify
-
-Ask them to say when the approval is done — do not poll silently and do not
-assume.
-
-Verification depends on what their token can see:
-
-```bash
-# Works only with the admin:org scope, which they may not want to grant:
-gh api /orgs/<owner>/installations --jq '.installations[].app_slug'
-```
-
-`GET /repos/{owner}/{repo}/installation` does **not** work here — it needs the
-App's own JWT, which no user token can produce.
-
-If neither is available, verify the honest way: open a pull request and look for
-the bot's review. That is the same thing the user cares about anyway.
-
-```bash
-gh pr create --fill
-```
-
-### 4. Configure
-
-Everything else lives at **OrcaRouter → Apps → OrcaCode Review**
-(<https://www.orcarouter.ai/>): models, review mode, severity rules, merge
-policy, rubric.
-
-**No `ORCAROUTER_API_KEY` secret is needed in the repo** — the App carries its
-own credentials. Do not add one; it would sit there unused and look load-bearing
-to the next person who reads the settings page.
-
-### 5. Make the gate real
-
-The App posts its own status check. Read the exact check name off the test PR
-rather than guessing it:
-
-```bash
-gh pr checks <number>
-```
-
-Then require that check under **Settings → Branches / Rulesets → Require status
-checks to pass**. Until it is required, a red check blocks nothing.
-
-### 6. Report
-
-Same rules as Action mode: what is in place, what is not, and any outstanding
-action as a copy-pasteable command. If the approval never happened, say the
-install is **not** complete — an unapproved App reviews nothing and reports no
-error.
-
-## Do not install both
-
-The Action and the App both review the same pull requests. Running them together
-gives every PR two sets of comments and bills two reviews.
-
-Before installing either, check for the other:
-
-- Action present → `.github/workflows/orca-code-review.yml` exists on the base branch.
-- App present → a bot review or an extra check on a recent PR.
-
-If the user has one and wants the other, remove the first — [Uninstall](#uninstall)
-for the Action, or the App's own page on GitHub for the App. Removing the Action
-is the reversible one, so prefer that direction when they are unsure.
 
 ## Reconfigure
 

--- a/skills/setup-orca-code-review/references/troubleshooting.md
+++ b/skills/setup-orca-code-review/references/troubleshooting.md
@@ -83,18 +83,19 @@ Fix by pinning a newer tag or an immutable commit SHA instead of `@v1`.
 
 ## Every PR gets two sets of comments
 
-The Action and the GitHub App are both installed. They review the same pull
-requests independently, so the repo pays twice and the author reads everything
-twice.
+Something besides this workflow is also reviewing. Most often the OrcaCode
+Review **GitHub App** is installed on the repo — this skill does not install it,
+but somebody may have added it directly. Both review the same pull requests, so
+the repo pays twice and the author reads everything twice.
 
 | Check | How |
 | --- | --- |
-| Action present | `git show origin/<default>:.github/workflows/orca-code-review.yml` |
-| App present | A bot review, or a check on a recent PR that no workflow in the repo produces |
+| This workflow | `git show origin/<default>:.github/workflows/orca-code-review.yml` |
+| Something else | A bot review, or a check on a recent PR that no workflow in the repo produces |
 
-Keep one. Removing the Action is the reversible half — delete the workflow (drop
-the required check first). Removing the App means revoking its installation on
-GitHub, which is a permission change someone with admin rights has to make.
+Keep one. Removing the workflow is the reversible half — delete it, dropping the
+required check first. Revoking an App installation is a permission change only
+someone with admin rights can make.
 
 ## Merges are not actually blocked
 


### PR DESCRIPTION
One install path now — the Action. **BREAKING** for anyone who asked the skill for App mode.

## Gone

- the `### 0. Pick the mode` step
- the whole `## Install — GitHub App mode` section
- the `## Do not install both` warning
- App trigger phrases in the frontmatter `description`

Install opens on Preflight again, steps renumbered 1–8. **151 lines out of SKILL.md.**

## Why it was the weaker half

Installing a GitHub App is a permission grant, and GitHub requires a human to approve it on a web page. The agent could only ever hand over a link and wait. On an org repo the person running the skill usually can't approve it at all — which we proved on this very account: `admin: false`, `role: member`.

The Action needs write access, and the agent finishes it end to end.

## What stays

The double-review symptom, reworded. The App still exists at `github.com/apps/orcacode-review` and someone may install it directly, so a repo can still end up with two reviewers. The entry now says plainly that this skill isn't what put it there.

## Tests swapped, not deleted

The four App-mode assertions described a path that no longer exists. Three replace them:

- the skill offers exactly one way to install — no `GitHub App mode`, no `installations/new` URL
- the install flow opens on Preflight with no mode question, **and the step numbers are contiguous 1–8** — removing a step is exactly where an off-by-one hides, and a skill that skips a number reads as a truncated file
- the double-review symptom is still documented, and still says this skill doesn't install the App

410 passing.

## One thing I did not do

The demo recording still contains the App-mode segment. I changed the README alt text so it no longer claims otherwise, but didn't re-cut the video — say the word and I'll rebuild it as install + Action only, which also brings it under a minute.

1.5.0 — merging publishes it.