### PR TITLE
fix: clear the 👀, which the identity fallback silently prevented

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1621,7 +1621,16 @@ runs:
           echo "github-token belongs to a user, not an app; leaving reactions alone"
           exit 0
         fi
-        ME=$(gh api user --jq .login 2>/dev/null || echo "github-actions[bot]")
+        # SAME TRAP AS THE TYPE PROBE, and it survived the fix to that one: with an
+        # installation token `gh api user` can exit 0 and print nothing, so
+        # `|| echo` never fires and ME came back EMPTY. The delete filter then read
+        # `select(.user.login=="")`, matched nothing, and the 👀 stayed on the PR
+        # for ever while the step reported success. Observed on a clean run that
+        # placed both 👀 and 👍 and cleared neither.
+        #
+        # Test the VALUE, not the exit status.
+        ME=$(gh api user --jq .login 2>/dev/null) || ME=""
+        [ -n "$ME" ] || ME="github-actions[bot]"
 
         # ------------------------------------------------------------------
         # 👀 — it said "I am looking at this", and the run has stopped looking.


### PR DESCRIPTION
The type probe was fixed in #42; this is the same trap one line down, in the same step, and it survived.

```bash
ME=$(gh api user --jq .login 2>/dev/null || echo "github-actions[bot]")
```

With an installation token that call can exit 0 and print nothing, so `|| echo` never fires and `ME` comes back **empty**. The delete filter then reads `select(.user.login=="")`, matches nothing, and the step reports success having removed nothing — the 👀 stays on the PR for ever.

Observed on a clean run: 👀 placed, 👍 placed, neither cleared, both still on the PR authored by `github-actions[bot]`.

Tests the VALUE rather than the exit status, which is what the type probe now does too. Any future identity read in this step wants the same shape — the exit status of that endpoint is not a reliable signal for an installation token.