### PR TITLE
release: 2.0.0 — the Action is the only install path, and the CLI drops itself

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Skills for OrcaRouter products.",
-    "version": "1.5.0"
+    "version": "2.0.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orca-code-review",
   "description": "Set up, reconfigure, troubleshoot, and remove OrcaCode Review — AI pull-request review powered by OrcaRouter — in any GitHub repository.",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "author": {
     "name": "Continuum-AI-Corp",
     "url": "https://github.com/Continuum-AI-Corp"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -66,6 +66,29 @@ The repo and the action stay `orca-code-review`.
 `--access public` ships it private and the documented install command 404s for
 everyone outside the org.
 
+#### The `1.x` line was withdrawn; `2.0.0` is the floor
+
+`@orcarouter/code-review` starts at **2.0.0** on the registry. 1.0.2 through
+1.5.0 were published on 25–26 Aug 2026 and unpublished inside npm's 72-hour
+window, so the packument shows one version and its history looks truncated —
+it is not. What went with them:
+
+- **App mode.** Up to 1.4.0 the skill offered a GitHub App install as an
+  alternative to the Action. Installing an App is a permission grant only a
+  human can approve on a web page, so the agent could only hand over a link;
+  1.5.0 dropped it and 2.0.0 is the first version published without it. The
+  major marks that break rather than leaving it in a minor nobody can install.
+- **The self-dependency.** 1.1.0 through 1.5.0 declared
+  `@orcarouter/code-review: ^1.0.2` as a dependency *of itself*, so every
+  `npx` pulled a second, older copy of the CLI. Removed in 2.0.0 and pinned by
+  a test — see "the CLI ships with no dependencies" in
+  `scripts/installer.test.mjs`.
+
+Unpublishing was the right call only because the line was two days old with no
+known consumers. It is not the default: outside the 72-hour window npm refuses,
+a withdrawn number can never be reused, and anyone pinned to it breaks with an
+E404 rather than a warning. **Deprecate instead** — see below.
+
 #### The unscoped `orcacode-review` name is retired
 
 1.0.0 and 1.0.1 were published unscoped under a personal account, before the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,27 +1,12 @@
 {
   "name": "@orcarouter/code-review",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orcarouter/code-review",
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "@orcarouter/code-review": "^1.0.2"
-      },
-      "bin": {
-        "orcacode-review": "bin/orcacode-review.mjs"
-      },
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
-    "node_modules/@orcarouter/code-review": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@orcarouter/code-review/-/code-review-1.0.2.tgz",
-      "integrity": "sha512-PsM9S+qAN6bDLzRU600fGNrSzjy+DfGMcel49iFFe8FsbZ4JRtoWbfMfEq5yemRD3KbR3FbkBW/xB1GEHhs+FQ==",
+      "version": "2.0.0",
       "license": "MIT",
       "bin": {
         "orcacode-review": "bin/orcacode-review.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcarouter/code-review",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "One-command installer for OrcaCode Review — AI pull-request review powered by OrcaRouter.",
   "bin": {
     "orcacode-review": "bin/orcacode-review.mjs"
@@ -38,8 +38,5 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
-  },
-  "dependencies": {
-    "@orcarouter/code-review": "^1.0.2"
   }
 }

--- a/scripts/installer.test.mjs
+++ b/scripts/installer.test.mjs
@@ -162,6 +162,18 @@ test("a scoped package declares public access", () => {
   assert.equal(PKG.publishConfig?.access, "public");
 });
 
+test("the CLI ships with no dependencies", () => {
+  // `npx` downloads the whole tree before running anything, so a dependency is
+  // latency on every install. 1.1.0 through 1.5.0 shipped with the package
+  // depending on ITSELF at ^1.0.2 — every npx fetched a second, older copy of
+  // the CLI into node_modules, and nothing failed, so five releases carried it.
+  // A self-reference is also a registry dependent, which is why this is a test
+  // and not a note in RELEASE.md.
+  for (const field of ["dependencies", "peerDependencies", "optionalDependencies"]) {
+    assert.deepEqual(Object.keys(PKG[field] ?? {}), [], `${field} must stay empty`);
+  }
+});
+
 test("the installed command is short even though the package name is scoped", () => {
   // `npm i -g` creates a command named by the bin KEY, not the package name.
   assert.deepEqual(Object.keys(PKG.bin), ["orcacode-review"]);


### PR DESCRIPTION
Cuts the release that carries #41 (App mode gone from the skill) and #42, and fixes a dependency the package should never have had.

## The package depended on itself

1.1.0 added `@orcarouter/code-review: ^1.0.2` to its own `dependencies`, and 1.1.0 → 1.5.0 all shipped it. Every `npx @orcarouter/code-review` downloaded a second, older copy of the CLI into `node_modules` before running the one it came for — latency on the first thing a new user does, against a `RELEASE.md` that already said the CLI has no dependencies.

Nothing failed, which is why it survived five releases: the bin resolves from the top level, so the nested copy was dead weight rather than a wrong entry point. It is also a registry dependent, and npm reads dependents when deciding whether a version may be withdrawn.

Pinned by a test now, not a note — `dependencies`, `peerDependencies` and `optionalDependencies` must all be empty.

## 2.0.0, not 1.5.1

1.5.0 shipped the App-mode removal as a minor. The 1.x line is being unpublished inside npm's 72-hour window, so 2.0.0 is the first version on the registry a user can install. The major is where the break belongs, and a lone `1.5.1` would imply a history the packument no longer has.

`RELEASE.md` records what went with the withdrawn versions (App mode, the self-dependency), and says plainly that unpublishing was defensible only for a two-day-old line with no known consumers — deprecation is the default everywhere else.

## Release mechanics

- Three versions move together, per gate 1: `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`.
- Merging this triggers `publish.yml`, which publishes 2.0.0 after gates 1–5 and proves it public with gate 6.
- 1.0.2 → 1.5.0 get unpublished after 2.0.0 is live on the registry, so the package is never versionless.
- Test suite: 412 pass, 0 fail. Tarball packs `bin/` + the skill, 14 files.