### PR TITLE
chore: current weights in the pasteable recipe

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -937,7 +937,8 @@ runs:
             # stamps x-cr-lens: judge, so the recipe's judge rule picks the model.
             #
             # Same model as before — the shipped recipe routes that rule to
-            # deepseek-v4-pro, which is what judge-model used to name. What moves is
+            # a model of its own choosing, which is what judge-model used to name
+            # directly. What moves is
             # where the choice lives, so a workspace can price its judge by editing its
             # own recipe rather than waiting for a release.
             #

--- a/recipes/orcacode-review.dsl.yaml
+++ b/recipes/orcacode-review.dsl.yaml
@@ -46,7 +46,7 @@
 #   the L2 judge — stamps `x-cr-lens: judge`, so the rule below claims it
 #
 # Swap in anything your OrcaRouter workspace can reach (openai/gpt-5.5,
-# anthropic/claude-opus-4-8, z-ai/glm-5.1, deepseek/deepseek-v4-pro). The default
+# anthropic/claude-opus-4-8, z-ai/glm-5.1, z-ai/glm-5.3). The default
 # is the single highest-leverage change you can make to review quality — nothing
 # else in this recipe affects what the reviewer can see or say.
 #
@@ -64,6 +64,6 @@ version: 1
 rules:
   - id: judge
     when: 'headers["x-cr-lens"] == "judge"'
-    use: { model: "deepseek/deepseek-v4-pro" }
+    use: { model: "z-ai/glm-5.3" }
 default:
-  model: "deepseek/deepseek-v4-flash"
+  model: "deepseek/deepseek-v4-flash-0731"

--- a/scripts/judge.mjs
+++ b/scripts/judge.mjs
@@ -51,7 +51,7 @@ for (let i = 0; i < rest.length; i += 1) {
   }
   else if (rest[i] === "--model") modelOverride = rest[++i];
 }
-if (!file) { console.error("usage: node judge.mjs <filtered.json> [--out f] [--threshold 0.7] [--model deepseek/deepseek-v4-pro]"); process.exit(2); }
+if (!file) { console.error("usage: node judge.mjs <filtered.json> [--out f] [--threshold 0.7] [--model orcarouter/<router>]"); process.exit(2); }
 
 // Env vars first (production); config.json only as a local-harness fallback.
 let llmUrl = process.env.OCR_LLM_URL || null;


### PR DESCRIPTION
Reviewer `deepseek/deepseek-v4-flash` → `deepseek/deepseek-v4-flash-0731`, judge `deepseek/deepseek-v4-pro` → `z-ai/glm-5.3`, matching the control plane's provisioning constant (OrcaRouter-O2#1440).

Both verified present and in the `default` group on the live gateway's `/api/pricing`. The request named "0730"; `0731` is the dated weight.

Also unpins two docs from a model that is no longer the one used: the `judge-model` note in `action.yml`, and `judge.mjs`'s usage line — which showed `deepseek-v4-pro` as its example and therefore read as a default. It now shows the router alias, which is what the action actually passes.

This file is what a BYO consumer pastes; the constant in the other repo is what setup writes. Nothing here can assert they agree — see `scripts/recipe.test.mjs` for what is assertable instead.