### PR TITLE
fix: fail closed when the L2 judge is unavailable, and name which gate closed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -985,8 +985,17 @@ runs:
             # success. That is why the provisioned recipe carries the rule, and why
             # setting judge-model explicitly stays the way to pin a model outright.
             L2_MODEL="${JUDGE_MODEL:-$ROUTER}"
-            if node "$JUDGE" "$1" --model "$L2_MODEL" --threshold "$JUDGE_THRESHOLD" --out "$L2_OUT" 2>&1 \
-               && [ -s "$L2_OUT" ]; then
+            # CAPTURED, not just streamed, so the failure branch can name WHICH
+            # failure this was. The judge exits 1 for a 400, a 401, a missing
+            # endpoint and a model that answered with prose, and its exit code
+            # tells those apart from each other not at all — the reason only ever
+            # existed in its stderr. Everything is echoed below either way, so the
+            # log reads exactly as before.
+            L2_LOG="${1%.json}.l2.log"
+            L2_RC=0
+            node "$JUDGE" "$1" --model "$L2_MODEL" --threshold "$JUDGE_THRESHOLD" --out "$L2_OUT" > "$L2_LOG" 2>&1 || L2_RC=$?
+            cat "$L2_LOG"
+            if [ "$L2_RC" = "0" ] && [ -s "$L2_OUT" ]; then
               L2_IN_COUNT=$(node -pe "(require('$1').comments||[]).length")
               L2_OUT_COUNT=$(node -pe "(require('$L2_OUT').comments||[]).length")
               echo "L2 judge ($L2_MODEL, thr=$JUDGE_THRESHOLD): $L2_IN_COUNT -> $L2_OUT_COUNT"
@@ -1009,8 +1018,27 @@ runs:
               # So an unavailable judge fails the pass. `precision-filter: "false"`
               # remains the supported way to run without a judge, and it skips L1
               # too, which is the honest version of that choice.
-              echo "::error::L2 judge unavailable — failing closed (L1 output is not publishable on its own)"
-              printf 'the L2 judge was unavailable' > "$RUNNER_TEMP/judge-unavailable"
+              # NAME THE FAILURE CLASS, because they are not the same problem and
+              # do not have the same fix. A 502 is the gateway having a moment and
+              # is worth re-running; a 401 is a key the workspace has to correct;
+              # a model answering in prose is a routing or recipe problem. Calling
+              # all three "unavailable after retries" sends the reader to wait out
+              # an outage that is not happening — the same wrong-cause reading
+              # this pass exists to end, one layer up.
+              #
+              # FIRST line, not the last: the judge prints "judge did not return
+              # JSON:" followed by a dump of what the model actually said, so a
+              # tail would quote a fragment of the bad completion in place of the
+              # reason. On a failing exit nothing else has been printed, so the
+              # first line is the message.
+              if [ "$L2_RC" = "0" ]; then
+                L2_REASON="it exited cleanly but wrote no output"
+              else
+                L2_REASON=$(head -n 1 "$L2_LOG")
+                [ -n "$L2_REASON" ] || L2_REASON="it exited $L2_RC without a message"
+              fi
+              echo "::error::L2 judge failed — $L2_REASON — failing closed (L1 output is not publishable on its own)"
+              printf '%s' "$L2_REASON" > "$RUNNER_TEMP/judge-unavailable"
               JUDGE_FAILED=1
               # Restore engine's block if we snapshotted one; else clear any
               # L2-authored block so a sidecar guardrail hit doesn't surface as
@@ -1048,7 +1076,7 @@ runs:
             if [ -f "$RUNNER_TEMP/wallclock-timeout" ]; then
               echo "::error::$BRAND: $(cat "$RUNNER_TEMP/wallclock-timeout") — engine killed, failing closed. Bump the 'timeout-minutes' input for very large PRs or slow-per-call models."
             elif [ -f "$RUNNER_TEMP/judge-unavailable" ]; then
-              echo "::error::$BRAND: the L2 judge was unavailable after retries — failing closed. Findings are not published unjudged; set 'precision-filter: false' to review without a judge."
+              echo "::error::$BRAND: the L2 judge failed — $(cat "$RUNNER_TEMP/judge-unavailable") — failing closed. Findings are not published unjudged; set 'precision-filter: false' to review without a judge."
             else
               echo "::error::$BRAND: review engine produced no usable result — failing closed. The log carries a reason= tag naming which check failed."
             fi

--- a/action.yml
+++ b/action.yml
@@ -147,8 +147,13 @@ inputs:
       drops findings whose snippet does not match the claimed path; then an
       LLM judge (L2) clusters findings by root cause and drops
       low-confidence ones. Set to `"false"` to post the engine's raw
-      findings directly. Both layers are soft-fail — errors keep the prior
-      stage's findings and never abort the review.
+      findings directly — that skips BOTH layers, and is the supported way to
+      review without a judge.
+
+      L1 is soft-fail: if it errors the engine's findings carry forward. L2 is
+      NOT. L1's output is not publishable on its own, so a judge still
+      unavailable after retries fails the run closed rather than posting
+      unjudged findings.
     required: false
     default: "true"
   judge-model:
@@ -468,7 +473,11 @@ runs:
         # differently from the workspace default, whereas which severities a
         # reader SEES is the workspace's call. Defaulting to every severity means
         # a gateway that predates the field behaves exactly as before.
-        REPORT_ON=$(setting report_on "P0,P1,P2,P3")
+        # Agrees with settings.mjs DEFAULTS on purpose. settings.mjs always writes
+        # a defaulted file, so this fires only if that file is missing or
+        # unreadable — and two different answers to the same question is how one
+        # of them ends up wrong without anyone noticing.
+        REPORT_ON=$(setting report_on "P0,P1")
         RUBRIC=$(setting rubric "")
 
         # PRECEDENCE (documented in the README): an explicit `with:` input that
@@ -904,9 +913,13 @@ runs:
           # produced a usable JSON result on this pass — a timeout or crash
           # leaves nothing to filter, so we skip straight to CHECK which
           # will fail closed on rc anyway. Both layers write to a temp file
-          # first and only overwrite $1 on success (fail-safe: any
-          # postprocessing error keeps the prior stage's findings, never
-          # aborts the review or corrupts the engine output).
+          # first and only overwrite $1 on success, so no postprocessing error
+          # can corrupt the engine output.
+          #
+          # L1 is fail-safe in the full sense: an error there keeps the engine's
+          # findings and the review continues. L2 is not — see the judge branch
+          # below for why an unavailable judge has to fail the pass.
+          JUDGE_FAILED=""
           if [ "$PRECISION_FILTER" = "true" ] && [ "$rc" = "0" ] && [ -s "$1" ] \
              && node -e "process.exit((require(process.argv[1]).comments||[]).length>0?0:1)" "$1" 2>/dev/null; then
             echo "::group::Precision filter — $2"
@@ -960,10 +973,23 @@ runs:
                 mv -f "$POLICY_BLOCK_SNAPSHOT" "$POLICY_BLOCK"
               fi
             else
-              echo "::warning::L2 judge failed — keeping L1 findings"
-              # L2 failed. Restore engine's block if we snapshotted one; else
-              # clear any L2-authored block so a sidecar guardrail hit doesn't
-              # surface as the engine's own block on the primary review.
+              # L1 AND L2 ARE ONE STAGE, NOT TWO. L1's output is not a shippable
+              # review: it is the engine's raw findings with mismatched snippets
+              # re-homed, still carrying the duplicate and low-value findings that
+              # L2 exists to cluster and drop. Publishing it because the judge was
+              # unreachable ships exactly the noise the filter was turned on to
+              # remove — worse for the reader than no review, and it arrives
+              # looking like a finished one.
+              #
+              # So an unavailable judge fails the pass. `precision-filter: "false"`
+              # remains the supported way to run without a judge, and it skips L1
+              # too, which is the honest version of that choice.
+              echo "::error::L2 judge unavailable — failing closed (L1 output is not publishable on its own)"
+              printf 'the L2 judge was unavailable' > "$RUNNER_TEMP/judge-unavailable"
+              JUDGE_FAILED=1
+              # Restore engine's block if we snapshotted one; else clear any
+              # L2-authored block so a sidecar guardrail hit doesn't surface as
+              # the engine's own block on the primary review.
               if [ -f "$POLICY_BLOCK_SNAPSHOT" ]; then
                 mv -f "$POLICY_BLOCK_SNAPSHOT" "$POLICY_BLOCK"
               else
@@ -972,6 +998,7 @@ runs:
             fi
             unset POLICY_BLOCK_SNAPSHOT
             echo "::endgroup::"
+            [ -z "$JUDGE_FAILED" ] || return 1
           fi
           node "$CHECK" "$1" "$rc"
         }
@@ -989,10 +1016,16 @@ runs:
         #   $4 = extra passes allowed
         run_review() {
           if ! run_pass "$RESULT" "$1" "$2" "$3"; then
+            # WHICH GATE FAILED, in the summary and not only inside a collapsed
+            # log group. These all used to print the same "no usable result", so a
+            # reader could not tell an engine crash from a partial run from an
+            # unavailable judge, and picked whichever cause was last in the log.
             if [ -f "$RUNNER_TEMP/wallclock-timeout" ]; then
               echo "::error::$BRAND: $(cat "$RUNNER_TEMP/wallclock-timeout") — engine killed, failing closed. Bump the 'timeout-minutes' input for very large PRs or slow-per-call models."
+            elif [ -f "$RUNNER_TEMP/judge-unavailable" ]; then
+              echo "::error::$BRAND: the L2 judge was unavailable after retries — failing closed. Findings are not published unjudged; set 'precision-filter: false' to review without a judge."
             else
-              echo "::error::$BRAND: review engine produced no usable result — failing closed."
+              echo "::error::$BRAND: review engine produced no usable result — failing closed. The log carries a reason= tag naming which check failed."
             fi
             exit 1
           fi

--- a/action.yml
+++ b/action.yml
@@ -221,7 +221,8 @@ runs:
           "$RUNNER_TEMP/cr-facts.json" "$RUNNER_TEMP/proxy.out" "$RUNNER_TEMP/proxy.err" \
           "$RUNNER_TEMP/policy-block.json" \
           "$RUNNER_TEMP/pr.diff" "$RUNNER_TEMP/diff-guard.json" "$RUNNER_TEMP/prev-summary.md" \
-          "$RUNNER_TEMP/wallclock-timeout" "$RUNNER_TEMP/cr-usage.jsonl" \
+          "$RUNNER_TEMP/wallclock-timeout" "$RUNNER_TEMP/judge-unavailable" \
+          "$RUNNER_TEMP/cr-usage.jsonl" \
           "$RUNNER_TEMP/cr-clean" \
           "$RUNNER_TEMP/result.l1.json" "$RUNNER_TEMP/result.l2.json" \
           "$RUNNER_TEMP/result-extra.l1.json" "$RUNNER_TEMP/result-extra.l2.json"
@@ -919,9 +920,19 @@ runs:
           # L1 is fail-safe in the full sense: an error there keeps the engine's
           # findings and the review continues. L2 is not — see the judge branch
           # below for why an unavailable judge has to fail the pass.
+          #
+          # A PARTIAL RESULT IS ALREADY DOOMED, so do not spend the filter on
+          # it. CHECK fails closed on any non-empty `warnings`, so a pass that
+          # carries them cannot be published however the judge rules. Filtering
+          # anyway buys a judge call for output nobody will read — and if THAT
+          # call is what fails, the summary blames "the L2 judge was
+          # unavailable" for a run whose actual defect was a partial engine
+          # result, the exact mis-attribution the reason= tags were added to
+          # end. Falling through to CHECK lets reason=partial name it, and
+          # name the warnings with it.
           JUDGE_FAILED=""
           if [ "$PRECISION_FILTER" = "true" ] && [ "$rc" = "0" ] && [ -s "$1" ] \
-             && node -e "process.exit((require(process.argv[1]).comments||[]).length>0?0:1)" "$1" 2>/dev/null; then
+             && node -e "const r=require(process.argv[1]);process.exit((r.comments||[]).length>0&&(r.warnings||[]).length===0?0:1)" "$1" 2>/dev/null; then
             echo "::group::Precision filter — $2"
             L1_OUT="${1%.json}.l1.json"
             if node "$POSTFILTER" "$1" "$GITHUB_WORKSPACE" "$HEAD" --out "$L1_OUT" 2>&1 \
@@ -1738,7 +1749,8 @@ runs:
           "$RUNNER_TEMP/cr-facts.json" "$RUNNER_TEMP/proxy.out" "$RUNNER_TEMP/proxy.err" \
           "$RUNNER_TEMP/policy-block.json" \
           "$RUNNER_TEMP/pr.diff" "$RUNNER_TEMP/diff-guard.json" "$RUNNER_TEMP/prev-summary.md" \
-          "$RUNNER_TEMP/wallclock-timeout" "$RUNNER_TEMP/cr-usage.jsonl" \
+          "$RUNNER_TEMP/wallclock-timeout" "$RUNNER_TEMP/judge-unavailable" \
+          "$RUNNER_TEMP/cr-usage.jsonl" \
           "$RUNNER_TEMP/cr-clean" \
           "$RUNNER_TEMP/result.l1.json" "$RUNNER_TEMP/result.l2.json" \
           "$RUNNER_TEMP/result-extra.l1.json" "$RUNNER_TEMP/result-extra.l2.json"

--- a/action.yml
+++ b/action.yml
@@ -225,7 +225,8 @@ runs:
           "$RUNNER_TEMP/cr-usage.jsonl" \
           "$RUNNER_TEMP/cr-clean" \
           "$RUNNER_TEMP/result.l1.json" "$RUNNER_TEMP/result.l2.json" \
-          "$RUNNER_TEMP/result-extra.l1.json" "$RUNNER_TEMP/result-extra.l2.json"
+          "$RUNNER_TEMP/result-extra.l1.json" "$RUNNER_TEMP/result-extra.l2.json" \
+          "$RUNNER_TEMP/result.l2.log" "$RUNNER_TEMP/result-extra.l2.log"
 
     - name: Resolve PR refs
       id: pr
@@ -1037,7 +1038,16 @@ runs:
                 L2_REASON=$(head -n 1 "$L2_LOG")
                 [ -n "$L2_REASON" ] || L2_REASON="it exited $L2_RC without a message"
               fi
-              echo "::error::L2 judge failed — $L2_REASON — failing closed (L1 output is not publishable on its own)"
+              # STATED, NOT ADJUDICATED. Whether a failed judge ends the run is
+              # the caller's call, not this function's: on the mandatory pass it
+              # is fatal, on a best-effort exhaustive pass run_review warns and
+              # keeps what it has. An `::error:: … failing closed` here put a red
+              # annotation claiming a failure onto runs that went green — the same
+              # register of wrong-claim this pass exists to remove. Both callers
+              # already print the consequence, so this is a plain log line inside
+              # the group the operator is already reading. Matches the wall-clock
+              # marker above, which reports and lets run_review adjudicate.
+              echo "L2 judge failed — $L2_REASON (L1 output is not publishable on its own, so this pass yields nothing)"
               printf '%s' "$L2_REASON" > "$RUNNER_TEMP/judge-unavailable"
               JUDGE_FAILED=1
               # Restore engine's block if we snapshotted one; else clear any
@@ -1107,7 +1117,15 @@ runs:
               # Otherwise a benign tooling failure (engine crash / partial
               # result): extra depth is best-effort, so warn and END exhaustion,
               # keeping the findings already in hand.
-              echo "::warning::$BRAND: exhaustive pass $extra produced no usable result — keeping the findings so far."
+              # Carry the reason into the downgrade. Without this a judge failure
+              # reads as "no usable result", which is what an engine crash also
+              # reads as — and the reason is the only thing that tells an operator
+              # whether to re-run or fix a key.
+              if [ -f "$RUNNER_TEMP/judge-unavailable" ]; then
+                echo "::warning::$BRAND: exhaustive pass $extra — the L2 judge failed ($(cat "$RUNNER_TEMP/judge-unavailable")) — keeping the findings so far."
+              else
+                echo "::warning::$BRAND: exhaustive pass $extra produced no usable result — keeping the findings so far."
+              fi
               break
             fi
             # Guard the merge + parse like the run_pass failure path above: an
@@ -1795,4 +1813,5 @@ runs:
           "$RUNNER_TEMP/cr-usage.jsonl" \
           "$RUNNER_TEMP/cr-clean" \
           "$RUNNER_TEMP/result.l1.json" "$RUNNER_TEMP/result.l2.json" \
-          "$RUNNER_TEMP/result-extra.l1.json" "$RUNNER_TEMP/result-extra.l2.json"
+          "$RUNNER_TEMP/result-extra.l1.json" "$RUNNER_TEMP/result-extra.l2.json" \
+          "$RUNNER_TEMP/result.l2.log" "$RUNNER_TEMP/result-extra.l2.log"

--- a/action.yml
+++ b/action.yml
@@ -930,9 +930,23 @@ runs:
           # result, the exact mis-attribution the reason= tags were added to
           # end. Falling through to CHECK lets reason=partial name it, and
           # name the warnings with it.
+          #
+          # `warnings` IS NORMALIZED THE WAY CHECK NORMALIZES IT — Array.isArray
+          # or nothing (check-result.mjs:44). The two predicates decide the fate
+          # of the same field and must not disagree: a non-array `warnings`, say
+          # the string "oops", has a nonzero .length, so a bare length test reads
+          # it as partial and skips the filter, while CHECK reads it as absent and
+          # publishes. That combination ships the engine's raw findings with no
+          # L1 and no L2 under `precision-filter: true` — the exact thing this
+          # pass fails closed to prevent, arriving as a green review.
+          #
+          # Which fixes the direction this test has to fail in: SKIPPING is the
+          # branch that can publish unjudged, so it may only be taken when the
+          # result is definitely partial. Anything malformed or unrecognized runs
+          # the filter.
           JUDGE_FAILED=""
           if [ "$PRECISION_FILTER" = "true" ] && [ "$rc" = "0" ] && [ -s "$1" ] \
-             && node -e "const r=require(process.argv[1]);process.exit((r.comments||[]).length>0&&(r.warnings||[]).length===0?0:1)" "$1" 2>/dev/null; then
+             && node -e "const r=require(process.argv[1]);const w=Array.isArray(r.warnings)?r.warnings:[];process.exit((r.comments||[]).length>0&&w.length===0?0:1)" "$1" 2>/dev/null; then
             echo "::group::Precision filter — $2"
             L1_OUT="${1%.json}.l1.json"
             if node "$POSTFILTER" "$1" "$GITHUB_WORKSPACE" "$HEAD" --out "$L1_OUT" 2>&1 \

--- a/scripts/check-result.mjs
+++ b/scripts/check-result.mjs
@@ -10,6 +10,13 @@
 // all mean we do NOT have a trustworthy result. Converting those into a clean
 // "no issues found" pass would let a bad key, gateway outage, or CLI crash
 // silently clear a PR — so we surface them as an unavailable review instead.
+//
+// EACH REASON PRINTS A DISTINCT `reason=` TAG, because the caller collapses all
+// of them into one "no usable result" error and an operator reading only that
+// cannot tell an engine crash from a partial run. That ambiguity cost a real
+// support round-trip: a run whose judge logged a 502 just before this failed was
+// read as "the judge threw the review away", when the judge is soft and the
+// engine was what failed.
 
 import fs from "node:fs";
 
@@ -17,7 +24,7 @@ const [file, rcRaw] = process.argv.slice(2);
 const rc = Number(rcRaw || "0");
 
 if (rc !== 0) {
-  console.error(`review unavailable: engine exited ${rc}`);
+  console.error(`reason=engine-exit review unavailable: engine exited ${rc}`);
   process.exit(1);
 }
 
@@ -25,18 +32,18 @@ let parsed;
 try {
   parsed = JSON.parse(fs.readFileSync(file, "utf8"));
 } catch (e) {
-  console.error(`review unavailable: no parseable result in ${file} (${e.message})`);
+  console.error(`reason=unparseable review unavailable: no parseable result in ${file} (${e.message})`);
   process.exit(1);
 }
 
 if (!Array.isArray(parsed.comments)) {
-  console.error("review unavailable: result has no `comments` array");
+  console.error("reason=no-comments review unavailable: result has no `comments` array");
   process.exit(1);
 }
 
 const warnings = Array.isArray(parsed.warnings) ? parsed.warnings : [];
 if (warnings.length > 0) {
-  console.error(`review partial: ${warnings.length} warning(s) — ${warnings.join("; ")}`);
+  console.error(`reason=partial review partial: ${warnings.length} warning(s) — ${warnings.join("; ")}`);
   process.exit(1);
 }
 

--- a/scripts/check-result.test.mjs
+++ b/scripts/check-result.test.mjs
@@ -16,7 +16,7 @@
 // it.
 
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -173,5 +173,76 @@ describe("output contract", () => {
     assert.equal(run(writeResult(OK), "0").stdout, "");
     assert.equal(run(writeResult(OK), "1").stdout, "");
     assert.equal(run(writeResult("{bad"), "0").stdout, "");
+  });
+});
+
+// THE PRECISION GATE AND THIS SCRIPT JUDGE THE SAME FIELD, so they must never
+// disagree about it. action.yml skips L1+L2 when the engine result looks
+// partial, on the reasoning that CHECK will reject it anyway — which holds only
+// while both read `warnings` the same way.
+//
+// They did not. The gate tested `(r.warnings||[]).length`, so a non-array value
+// like the string "oops" measured 4 and read as partial; CHECK normalizes any
+// non-array to [] and publishes. Skip plus publish is the combination that
+// ships the engine's raw findings with no L1 and no L2 under
+// `precision-filter: true` — unjudged output arriving as a green review, i.e.
+// exactly what the fail-closed judge branch exists to stop.
+//
+// Which sets the direction this predicate has to fail in: SKIPPING is the
+// branch that can publish unjudged, so it may only be taken when the result is
+// DEFINITELY partial. The real predicate is extracted from action.yml rather
+// than restated here, so editing one without the other fails this test.
+describe("the action's skip-the-filter predicate agrees with this script", () => {
+  const actionYml = readFileSync(join(SCRIPTS, "..", "action.yml"), "utf8");
+
+  // The `node -e "…"` program inside the precision gate's `if`.
+  const predicate = (() => {
+    const m = actionYml.match(/&& node -e "(const r=require\(process\.argv\[1\]\)[^"]*warnings[^"]*)"/);
+    assert.ok(m, "the precision gate's warnings predicate must exist in action.yml");
+    return m[1];
+  })();
+
+  const filtersRun = (file) => spawnSync("node", ["-e", predicate, file], { encoding: "utf8" }).status === 0;
+
+  // Every shape an engine (or a corrupted write) can put in `warnings`.
+  const shapes = {
+    "a real non-empty array": ["conventions lens failed"],
+    "an empty array": [],
+    "the field absent": undefined,
+    "null": null,
+    "a string": "oops",
+    "a number": 5,
+    "an object": { a: 1 },
+  };
+
+  for (const [name, warnings] of Object.entries(shapes)) {
+    test(`${name}: the filter is never skipped on a result CHECK will publish`, () => {
+      const body = { comments: [{ content: "[P2] a finding" }] };
+      if (warnings !== undefined) body.warnings = warnings;
+      const file = writeResult(body);
+
+      const skipped = !filtersRun(file);
+      const published = run(file, "0").status === 0;
+      assert.ok(
+        !(skipped && published),
+        `unjudged publish: filter skipped AND CHECK published for warnings=${JSON.stringify(warnings)}`,
+      );
+    });
+  }
+
+  test("a genuinely partial result is the one case that skips — and CHECK stops it", () => {
+    const file = writeResult({ comments: [{ content: "[P2] a" }], warnings: ["lens failed"] });
+    assert.equal(filtersRun(file), false, "a partial result must not spend a judge call");
+    const r = run(file, "0");
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /reason=partial/);
+  });
+
+  test("a clean result with findings still enters the filter", () => {
+    assert.equal(filtersRun(writeResult({ comments: [{ content: "[P2] a" }], warnings: [] })), true);
+  });
+
+  test("no findings means nothing to filter", () => {
+    assert.equal(filtersRun(writeResult({ comments: [], warnings: [] })), false);
   });
 });

--- a/scripts/judge.mjs
+++ b/scripts/judge.mjs
@@ -119,19 +119,21 @@ const body = JSON.stringify({
   messages: [{ role: "system", content: system }, { role: "user", content: user }],
 });
 
-// RETRYABLE UPSTREAM STATUSES. The same set the engine's own calls use, for the
-// same reason: these say "ask again", not "your request is wrong". This call had
-// no retry at all while every other LLM call in the pipeline had four, and a
-// single transient 502 was enough to take the judge out — which, now that L2 is
-// mandatory when precision filtering is on, takes the whole review with it.
-const RETRY_STATUS = new Set([408, 429, 500, 502, 503, 504, 522, 524]);
-const JUDGE_ATTEMPTS = 4;
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-
-// One attempt. Returns { res, raw } so the caller can decide on the status
-// WITHOUT re-reading a consumed body.
-async function judgeOnce() {
-  const res = await fetch(llmUrl, {
+// ONE REQUEST, AND DELIBERATELY NO RETRY HERE. In production OCR_LLM_URL is the
+// local fact proxy the action starts (action.yml), and fact-proxy.mjs already
+// retries 429/502/503/504 four times with backoff. A retry loop in this script
+// would multiply against that — four here times four there is sixteen upstream
+// requests for one judge call.
+//
+// It would also be a WIDER set than the proxy's on purpose-built ground: the
+// proxy excludes 500 because a 500 can mean the completion was produced and
+// billed, and replaying it buys the same bill twice. Anything added here would
+// bypass that policy without knowing it existed.
+//
+// Retry belongs at the proxy, which is the layer that knows whether the request
+// was idempotent. If this ever needs its own, it has to be the statuses the
+// proxy passes through, not a second copy of its list.
+const res = await fetch(llmUrl, {
   method: "POST",
   headers: {
     "content-type": "application/json",
@@ -151,38 +153,12 @@ async function judgeOnce() {
     "x-cr-lens": "judge",
   },
   body,
-  });
-  return { res, raw: await res.text() };
-}
-
-// THE RETRY LOOP. A transport error (DNS, reset, timeout) and a retryable
-// status are the same event from here: the answer has not arrived and asking
-// again may get one. A non-retryable status is terminal — repeating a 400 or a
-// 401 buys the same rejection and spends the workspace's quota doing it.
-//
-// The body of the LAST failure is what gets reported, so the log names the
-// actual reason rather than "attempt 4 failed". That line is how an operator
-// tells our gateway's own 5xx from one it passed through from upstream.
-let res = null, raw = "", lastErr = "";
-for (let attempt = 1; attempt <= JUDGE_ATTEMPTS; attempt += 1) {
-  try {
-    ({ res, raw } = await judgeOnce());
-    if (res.ok) break;
-    lastErr = `HTTP ${res.status}: ${raw.slice(0, 400)}`;
-    if (!RETRY_STATUS.has(res.status)) break;
-  } catch (e) {
-    res = null;
-    lastErr = `request failed: ${String(e && e.message ? e.message : e).slice(0, 400)}`;
-  }
-  if (attempt < JUDGE_ATTEMPTS) {
-    console.error(`judge: ${lastErr} — retrying (${attempt}/${JUDGE_ATTEMPTS - 1})`);
-    await sleep(500 * attempt);
-  }
-}
-if (!res || !res.ok) {
-  console.error(`judge failed after ${JUDGE_ATTEMPTS} attempt(s) — ${lastErr}`);
-  process.exit(1);
-}
+});
+const raw = await res.text();
+// The upstream body, not just the status: that text is how an operator tells the
+// gateway's own 5xx from one it passed through — and by the time it reaches here
+// the proxy has already spent its retries on it.
+if (!res.ok) { console.error(`HTTP ${res.status}: ${raw.slice(0, 400)}`); process.exit(1); }
 
 let content;
 try { content = JSON.parse(raw).choices[0].message.content; }

--- a/scripts/judge.mjs
+++ b/scripts/judge.mjs
@@ -224,18 +224,29 @@ let parsed;
 try { parsed = JSON.parse(jsonText); }
 catch (e) { console.error("judge did not return JSON:\n" + content.slice(0, 600)); process.exit(1); }
 
-// A TRUTHY NON-ARRAY `groups` IS A SCHEMA VIOLATION, and it must fail rather
-// than fall open. A string iterates by character and an object is not
-// iterable at all, so what used to happen was a throw a few lines down — and
-// falling open instead would keep every finding unjudged, which is the one
-// outcome the judge exists to prevent. Falsy stays as it was: absent or null
-// means the judge classified nothing, which the fail-open pass below handles
-// deliberately.
-if (parsed.groups && !Array.isArray(parsed.groups)) {
-  console.error(`judge returned a non-array groups (${typeof parsed.groups}): ${jsonText.slice(0, 600)}`);
+// `groups` MUST BE AN ARRAY, and the test names what is ALLOWED rather than
+// what is rejected. Two exemptions, both meaning "the judge classified
+// nothing", which the fail-open pass below handles deliberately: the field is
+// absent, or it is null. Everything else is a schema violation and fails.
+//
+// Not a truthiness test, which is what this was and what was wrong with it.
+// `false`, `0` and `""` are falsy AND non-arrays, so they slipped through to
+// the `|| []` below, every finding came out unclassified, the fail-open pass
+// kept all of them, and the judge exited 0 — publishing every finding as
+// JUDGED off a response that violated the schema. That is the precise outcome
+// this pass fails closed to prevent, and a reject-list guard reintroduced it
+// while looking like it closed it.
+//
+// An accept-list cannot have that shape of hole: a value that is neither
+// exemption nor an array has nowhere to go but the failure branch, whatever
+// type someone invents next.
+const groupsRaw = parsed.groups;
+const groupsOmitted = groupsRaw === undefined || groupsRaw === null;
+if (!groupsOmitted && !Array.isArray(groupsRaw)) {
+  console.error(`judge returned a non-array groups (${typeof groupsRaw}): ${jsonText.slice(0, 600)}`);
   process.exit(1);
 }
-const groups = parsed.groups || [];
+const groups = groupsOmitted ? [] : groupsRaw;
 const covered = new Set();
 for (const g of groups) for (const id of g.member_ids || []) covered.add(id);
 // Fail-open for findings the judge did not classify into any group: mark

--- a/scripts/judge.mjs
+++ b/scripts/judge.mjs
@@ -133,27 +133,44 @@ const body = JSON.stringify({
 // Retry belongs at the proxy, which is the layer that knows whether the request
 // was idempotent. If this ever needs its own, it has to be the statuses the
 // proxy passes through, not a second copy of its list.
-const res = await fetch(llmUrl, {
-  method: "POST",
-  headers: {
-    "content-type": "application/json",
-    [llmAuthHeader]: "Bearer " + llmToken,
-    // THE ANGLE, so a router recipe can put this call on its own model.
-    //
-    // --model is normally the router ALIAS (action.yml passes it when judge-model
-    // is unset), and an alias resolves through the workspace's DSL, which has no
-    // other way to tell a judge call from a review call: the reviewer stamps no
-    // angle. Without this header the judge takes the recipe's default — the
-    // reviewer's own model — and a judge scoring work its own model produced
-    // agrees with it, so the pass goes inert while still reporting success.
-    //
-    // Harmless when --model names a concrete model: nothing resolves an alias, so
-    // nothing reads the header. Sent unconditionally rather than only for aliases
-    // because "is this an alias" is the gateway's judgement, not this script's.
-    "x-cr-lens": "judge",
-  },
-  body,
-});
+// WRAPPED, because a transport failure is a failure class too and it has to
+// arrive named. `fetch` rejects rather than returning a response when it
+// cannot reach the endpoint at all, so without this the process dies on an
+// unhandled rejection and the first line of stderr is a path inside undici.
+// action.yml quotes that first line as the reason in its summary annotation,
+// which would turn "the gateway is unreachable" into a stack frame.
+//
+// The message alone is not enough either: fetch collapses every transport
+// failure into the string "fetch failed" and puts the part worth reading —
+// ECONNREFUSED, a DNS failure, a headers timeout — in `cause`.
+let res;
+try {
+  res = await fetch(llmUrl, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      [llmAuthHeader]: "Bearer " + llmToken,
+      // THE ANGLE, so a router recipe can put this call on its own model.
+      //
+      // --model is normally the router ALIAS (action.yml passes it when judge-model
+      // is unset), and an alias resolves through the workspace's DSL, which has no
+      // other way to tell a judge call from a review call: the reviewer stamps no
+      // angle. Without this header the judge takes the recipe's default — the
+      // reviewer's own model — and a judge scoring work its own model produced
+      // agrees with it, so the pass goes inert while still reporting success.
+      //
+      // Harmless when --model names a concrete model: nothing resolves an alias, so
+      // nothing reads the header. Sent unconditionally rather than only for aliases
+      // because "is this an alias" is the gateway's judgement, not this script's.
+      "x-cr-lens": "judge",
+    },
+    body,
+  });
+} catch (e) {
+  const cause = e?.cause?.code || e?.cause?.message || "";
+  console.error(`could not reach the LLM: ${e?.message || e}${cause ? ` (${cause})` : ""}`);
+  process.exit(1);
+}
 const raw = await res.text();
 // The upstream body, not just the status: that text is how an operator tells the
 // gateway's own 5xx from one it passed through — and by the time it reaches here

--- a/scripts/judge.mjs
+++ b/scripts/judge.mjs
@@ -21,6 +21,24 @@
 import fs from "node:fs";
 import os from "node:os";
 
+// A STABLE FIRST LINE, WHATEVER HAPPENS. action.yml lifts the first line of
+// this script's stderr into the job's user-facing L2 failure reason, so an
+// unforeseen throw reports a source-file path as "why your review failed" —
+// which names nothing and implies no fix. The guards further down cover the
+// malformed response shapes we know about; enumerating shapes is always one
+// shape short, so this covers the rest.
+//
+// The stack still follows on the next lines: the action echoes the whole log,
+// and only the FIRST line is promoted, so nothing needed for debugging is
+// lost by putting a summary in front of it.
+const crash = (label) => (e) => {
+  console.error(`judge crashed (${label}): ${e?.message || e}`);
+  if (e?.stack) console.error(e.stack);
+  process.exit(1);
+};
+process.on("uncaughtException", crash("uncaught"));
+process.on("unhandledRejection", crash("unhandled rejection"));
+
 // Parses a strict plain decimal (e.g. "0.7", "-1", "0.5"). Returns the number
 // or NaN. Deliberately does NOT use parseFloat — parseFloat stops at the
 // first non-numeric character so "0.8oops" would silently become 0.8 and
@@ -192,11 +210,31 @@ let content;
 try { content = JSON.parse(raw).choices[0].message.content; }
 catch (e) { console.error("bad completion envelope: " + raw.slice(0, 400)); process.exit(1); }
 
+// A 200 CAN STILL CARRY NOTHING TO READ. The envelope parses, `content` is
+// present, and it is null or a number — so the extraction above succeeds and
+// the `.replace` below throws instead. Type it here, where the raw response
+// is still in hand to quote.
+if (typeof content !== "string") {
+  console.error(`judge response had no text content (${content === null ? "null" : typeof content}): ${raw.slice(0, 400)}`);
+  process.exit(1);
+}
+
 const jsonText = content.replace(/^```(?:json)?/m, "").replace(/```$/m, "").trim();
 let parsed;
 try { parsed = JSON.parse(jsonText); }
 catch (e) { console.error("judge did not return JSON:\n" + content.slice(0, 600)); process.exit(1); }
 
+// A TRUTHY NON-ARRAY `groups` IS A SCHEMA VIOLATION, and it must fail rather
+// than fall open. A string iterates by character and an object is not
+// iterable at all, so what used to happen was a throw a few lines down — and
+// falling open instead would keep every finding unjudged, which is the one
+// outcome the judge exists to prevent. Falsy stays as it was: absent or null
+// means the judge classified nothing, which the fail-open pass below handles
+// deliberately.
+if (parsed.groups && !Array.isArray(parsed.groups)) {
+  console.error(`judge returned a non-array groups (${typeof parsed.groups}): ${jsonText.slice(0, 600)}`);
+  process.exit(1);
+}
 const groups = parsed.groups || [];
 const covered = new Set();
 for (const g of groups) for (const id of g.member_ids || []) covered.add(id);

--- a/scripts/judge.mjs
+++ b/scripts/judge.mjs
@@ -119,7 +119,19 @@ const body = JSON.stringify({
   messages: [{ role: "system", content: system }, { role: "user", content: user }],
 });
 
-const res = await fetch(llmUrl, {
+// RETRYABLE UPSTREAM STATUSES. The same set the engine's own calls use, for the
+// same reason: these say "ask again", not "your request is wrong". This call had
+// no retry at all while every other LLM call in the pipeline had four, and a
+// single transient 502 was enough to take the judge out — which, now that L2 is
+// mandatory when precision filtering is on, takes the whole review with it.
+const RETRY_STATUS = new Set([408, 429, 500, 502, 503, 504, 522, 524]);
+const JUDGE_ATTEMPTS = 4;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// One attempt. Returns { res, raw } so the caller can decide on the status
+// WITHOUT re-reading a consumed body.
+async function judgeOnce() {
+  const res = await fetch(llmUrl, {
   method: "POST",
   headers: {
     "content-type": "application/json",
@@ -139,9 +151,38 @@ const res = await fetch(llmUrl, {
     "x-cr-lens": "judge",
   },
   body,
-});
-const raw = await res.text();
-if (!res.ok) { console.error(`HTTP ${res.status}: ${raw.slice(0, 400)}`); process.exit(1); }
+  });
+  return { res, raw: await res.text() };
+}
+
+// THE RETRY LOOP. A transport error (DNS, reset, timeout) and a retryable
+// status are the same event from here: the answer has not arrived and asking
+// again may get one. A non-retryable status is terminal — repeating a 400 or a
+// 401 buys the same rejection and spends the workspace's quota doing it.
+//
+// The body of the LAST failure is what gets reported, so the log names the
+// actual reason rather than "attempt 4 failed". That line is how an operator
+// tells our gateway's own 5xx from one it passed through from upstream.
+let res = null, raw = "", lastErr = "";
+for (let attempt = 1; attempt <= JUDGE_ATTEMPTS; attempt += 1) {
+  try {
+    ({ res, raw } = await judgeOnce());
+    if (res.ok) break;
+    lastErr = `HTTP ${res.status}: ${raw.slice(0, 400)}`;
+    if (!RETRY_STATUS.has(res.status)) break;
+  } catch (e) {
+    res = null;
+    lastErr = `request failed: ${String(e && e.message ? e.message : e).slice(0, 400)}`;
+  }
+  if (attempt < JUDGE_ATTEMPTS) {
+    console.error(`judge: ${lastErr} — retrying (${attempt}/${JUDGE_ATTEMPTS - 1})`);
+    await sleep(500 * attempt);
+  }
+}
+if (!res || !res.ok) {
+  console.error(`judge failed after ${JUDGE_ATTEMPTS} attempt(s) — ${lastErr}`);
+  process.exit(1);
+}
 
 let content;
 try { content = JSON.parse(raw).choices[0].message.content; }

--- a/scripts/judge.mjs
+++ b/scripts/judge.mjs
@@ -134,16 +134,24 @@ const body = JSON.stringify({
 // was idempotent. If this ever needs its own, it has to be the statuses the
 // proxy passes through, not a second copy of its list.
 // WRAPPED, because a transport failure is a failure class too and it has to
-// arrive named. `fetch` rejects rather than returning a response when it
-// cannot reach the endpoint at all, so without this the process dies on an
-// unhandled rejection and the first line of stderr is a path inside undici.
-// action.yml quotes that first line as the reason in its summary annotation,
-// which would turn "the gateway is unreachable" into a stack frame.
+// arrive named. Without this the process dies on an unhandled rejection and
+// the first line of stderr is a path inside undici — and action.yml quotes
+// that first line as the reason in its summary annotation, so a dead gateway
+// would be reported to the operator as a stack frame.
+//
+// THE BODY READ IS INSIDE THE TRY, not just the fetch. `fetch` resolves as
+// soon as the response headers arrive, so a connection that dies mid-body
+// rejects at `res.text()` instead — with "terminated", from a different
+// undici frame. That is not a hypothetical here: fact-proxy relays headers
+// first and then destroys the connection on a mid-stream upstream failure
+// (fact-proxy.mjs, "the headers are out, so destroy the connection"), and
+// the proxy is what serves this call in production.
 //
 // The message alone is not enough either: fetch collapses every transport
 // failure into the string "fetch failed" and puts the part worth reading —
-// ECONNREFUSED, a DNS failure, a headers timeout — in `cause`.
+// ECONNREFUSED, ECONNRESET, a DNS failure, a headers timeout — in `cause`.
 let res;
+let raw;
 try {
   res = await fetch(llmUrl, {
     method: "POST",
@@ -166,12 +174,15 @@ try {
     },
     body,
   });
+  raw = await res.text();
 } catch (e) {
+  // "complete", not "reach": by the time a mid-body drop lands here the
+  // request did reach the gateway. The cause code is what separates the two —
+  // ECONNREFUSED never arrived, ECONNRESET/terminated arrived and was cut off.
   const cause = e?.cause?.code || e?.cause?.message || "";
-  console.error(`could not reach the LLM: ${e?.message || e}${cause ? ` (${cause})` : ""}`);
+  console.error(`could not complete the LLM request: ${e?.message || e}${cause ? ` (${cause})` : ""}`);
   process.exit(1);
 }
-const raw = await res.text();
 // The upstream body, not just the status: that text is how an operator tells the
 // gateway's own 5xx from one it passed through — and by the time it reaches here
 // the proxy has already spent its retries on it.

--- a/scripts/judge.test.mjs
+++ b/scripts/judge.test.mjs
@@ -189,56 +189,44 @@ async function judgeAgainstFlaky({ comments, failFor, status, reply, threshold }
   }
 }
 
-// A TRANSIENT 5xx MUST NOT TAKE THE JUDGE OUT. This call had no retry while
-// every other LLM call in the pipeline had four, so one 502 ended the judge —
-// and with L2 mandatory under precision filtering, that ends the review.
-describe("transient upstream failures are retried", () => {
+// RETRY BELONGS AT THE PROXY, NOT HERE. In production OCR_LLM_URL is the local
+// fact proxy, which already retries 429/502/503/504 four times — a loop in
+// judge.mjs multiplies against that (four times four upstream requests for one
+// judge call) and would replay statuses the proxy excludes on purpose, like a
+// 500 whose completion may already have been produced and billed.
+//
+// This pins the request count so that second layer cannot be reintroduced
+// without a test saying so out loud.
+describe("upstream failures are not retried in-process", () => {
   const keepAll = JSON.stringify({
     groups: [{ member_ids: [0], representative_id: 0, confidence: 0.9, keep: true }],
   });
 
   for (const status of [502, 503, 429, 500]) {
-    test(`a single ${status} is retried and the judge still succeeds`, async () => {
+    test(`a ${status} makes exactly one request and reports the body`, async () => {
       const r = await judgeAgainstFlaky({
         comments: [finding("a real finding")],
-        failFor: 1,
+        failFor: 99,
         status,
         reply: keepAll,
       });
-      assert.equal(r.status, 0, r.stderr);
-      assert.equal(r.calls, 2, "expected one retry after the first failure");
-      assert.equal(r.read().comments.length, 1);
+      assert.notEqual(r.status, 0);
+      assert.equal(r.calls, 1, "the proxy owns retries — this must not add a second layer");
+      assert.match(r.stderr, new RegExp(`HTTP ${status}`));
+      assert.match(r.stderr, /upstream is having a moment/);
     });
   }
 
-  test("retries are bounded and the last failure is what gets reported", async () => {
+  test("a recovered upstream still needs only the one request", async () => {
     const r = await judgeAgainstFlaky({
       comments: [finding("a real finding")],
-      failFor: 99,
+      failFor: 0,
       status: 502,
       reply: keepAll,
     });
-    assert.notEqual(r.status, 0);
-    assert.equal(r.calls, 4, "expected exactly 4 attempts, not unbounded retrying");
-    assert.match(r.stderr, /judge failed after 4 attempt\(s\)/);
-    // The body of the real failure, so an operator can tell OUR 5xx from one we
-    // passed through — "attempt 4 failed" would not.
-    assert.match(r.stderr, /HTTP 502/);
-    assert.match(r.stderr, /upstream is having a moment/);
-  });
-
-  // A 4xx that is not 429 says the request is wrong. Repeating it buys the same
-  // rejection and spends the workspace's quota doing it.
-  test("a non-retryable status fails on the first attempt", async () => {
-    const r = await judgeAgainstFlaky({
-      comments: [finding("a real finding")],
-      failFor: 99,
-      status: 400,
-      reply: keepAll,
-    });
-    assert.notEqual(r.status, 0);
-    assert.equal(r.calls, 1, "a 400 must not be retried");
-    assert.match(r.stderr, /HTTP 400/);
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(r.calls, 1);
+    assert.equal(r.read().comments.length, 1);
   });
 });
 

--- a/scripts/judge.test.mjs
+++ b/scripts/judge.test.mjs
@@ -150,6 +150,98 @@ const oneGroup = (over) =>
     ],
   });
 
+// LLM double that fails the first `failFor` requests with `status`, then
+// succeeds. Counts every request so a test can assert how many attempts the
+// judge actually made.
+async function startFlakyLlm({ failFor, status, reply }) {
+  let calls = 0;
+  const server = http.createServer((req, res) => {
+    req.on("data", () => {});
+    req.on("end", () => {
+      calls += 1;
+      if (calls <= failFor) {
+        res.writeHead(status, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { message: "upstream is having a moment" } }));
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ choices: [{ message: { content: reply } }] }));
+    });
+  });
+  const port = await listen(server);
+  return { port, calls: () => calls, close: () => new Promise((r) => server.close(r)) };
+}
+
+async function judgeAgainstFlaky({ comments, failFor, status, reply, threshold }) {
+  const llm = await startFlakyLlm({ failFor, status, reply });
+  try {
+    const input = writeInput(comments);
+    const out = join(dir, `${(seq += 1)}-out.json`);
+    const args = [input, "--out", out, "--model", "test/judge-model"];
+    if (threshold !== undefined) args.push("--threshold", String(threshold));
+    const r = await spawnJudge(args, {
+      OCR_LLM_URL: `http://127.0.0.1:${llm.port}/v1/chat/completions`,
+      OCR_LLM_TOKEN: "test-token",
+    });
+    return { ...r, out, calls: llm.calls(), read: () => JSON.parse(readFileSync(out, "utf8")) };
+  } finally {
+    await llm.close();
+  }
+}
+
+// A TRANSIENT 5xx MUST NOT TAKE THE JUDGE OUT. This call had no retry while
+// every other LLM call in the pipeline had four, so one 502 ended the judge —
+// and with L2 mandatory under precision filtering, that ends the review.
+describe("transient upstream failures are retried", () => {
+  const keepAll = JSON.stringify({
+    groups: [{ member_ids: [0], representative_id: 0, confidence: 0.9, keep: true }],
+  });
+
+  for (const status of [502, 503, 429, 500]) {
+    test(`a single ${status} is retried and the judge still succeeds`, async () => {
+      const r = await judgeAgainstFlaky({
+        comments: [finding("a real finding")],
+        failFor: 1,
+        status,
+        reply: keepAll,
+      });
+      assert.equal(r.status, 0, r.stderr);
+      assert.equal(r.calls, 2, "expected one retry after the first failure");
+      assert.equal(r.read().comments.length, 1);
+    });
+  }
+
+  test("retries are bounded and the last failure is what gets reported", async () => {
+    const r = await judgeAgainstFlaky({
+      comments: [finding("a real finding")],
+      failFor: 99,
+      status: 502,
+      reply: keepAll,
+    });
+    assert.notEqual(r.status, 0);
+    assert.equal(r.calls, 4, "expected exactly 4 attempts, not unbounded retrying");
+    assert.match(r.stderr, /judge failed after 4 attempt\(s\)/);
+    // The body of the real failure, so an operator can tell OUR 5xx from one we
+    // passed through — "attempt 4 failed" would not.
+    assert.match(r.stderr, /HTTP 502/);
+    assert.match(r.stderr, /upstream is having a moment/);
+  });
+
+  // A 4xx that is not 429 says the request is wrong. Repeating it buys the same
+  // rejection and spends the workspace's quota doing it.
+  test("a non-retryable status fails on the first attempt", async () => {
+    const r = await judgeAgainstFlaky({
+      comments: [finding("a real finding")],
+      failFor: 99,
+      status: 400,
+      reply: keepAll,
+    });
+    assert.notEqual(r.status, 0);
+    assert.equal(r.calls, 1, "a 400 must not be retried");
+    assert.match(r.stderr, /HTTP 400/);
+  });
+});
+
 describe("argument validation (no LLM call is made)", () => {
   test("a missing input file exits 2", async () => {
     const r = await spawnJudge([], {});

--- a/scripts/judge.test.mjs
+++ b/scripts/judge.test.mjs
@@ -498,15 +498,22 @@ describe("transport and envelope failures", () => {
     assert.match(r.stderr, /judge did not return JSON/);
   });
 
-  // AN UNREACHABLE GATEWAY IS A FAILURE CLASS TOO, and it has to arrive named.
-  // `fetch` rejects rather than returning a response when it cannot reach the
-  // endpoint at all, so with no catch the process died on an unhandled rejection
-  // and the first line of stderr was a path inside undici. action.yml quotes
-  // that first line as the reason in its summary annotation, which turned "the
-  // gateway is unreachable" into a stack frame — no class, no fix implied.
+  // A TRANSPORT FAILURE IS A FAILURE CLASS TOO, and it has to arrive named.
+  // With no catch the process died on an unhandled rejection and the first line
+  // of stderr was a path inside undici. action.yml quotes that first line as the
+  // reason in its summary annotation, so a dead gateway reached the operator as
+  // a stack frame — no class, no fix implied.
   //
-  // The no-stack-trace assertion is the load-bearing one: a `catch` that merely
-  // re-printed the error would still satisfy the message match.
+  // TWO SHAPES, not one, and the first fix only covered the first. `fetch`
+  // rejects when it cannot reach the endpoint at all, but RESOLVES as soon as
+  // response headers arrive — so a connection that dies mid-body rejects at
+  // `res.text()`, from a different undici frame, and stayed uncaught. Not
+  // hypothetical: fact-proxy relays headers first and then destroys the
+  // connection on a mid-stream upstream failure, and the proxy is what serves
+  // this call in production.
+  //
+  // The no-stack-trace assertions are the load-bearing ones: a `catch` that
+  // merely re-printed the error would still satisfy the message match.
   test("an unreachable endpoint is named, not a stack trace", async () => {
     // A port that was bound and released is reliably closed, unlike a guess.
     const probe = http.createServer();
@@ -520,9 +527,36 @@ describe("transport and envelope failures", () => {
     });
 
     assert.equal(r.status, 1);
-    assert.match(r.stderr, /could not reach the LLM/);
+    assert.match(r.stderr, /could not complete the LLM request/);
     assert.match(r.stderr, /ECONNREFUSED/, "the cause carries the part worth reading");
     assert.doesNotMatch(r.stderr, /node:internal/, "an unhandled rejection must not be the diagnostic");
+    assert.equal(existsSync(out), false);
+  });
+
+  test("a connection dropped mid-body is named too, not a stack trace", async () => {
+    // Headers out, then the socket dies — what fact-proxy does once it has
+    // already relayed headers. `fetch` has resolved by then, so this rejects at
+    // the body read, which the first version of the catch did not cover.
+    const server = http.createServer((req, res) => {
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(200, { "content-type": "application/json", "content-length": "9999" });
+        res.write('{"choices"');
+        setTimeout(() => res.socket.destroy(), 20);
+      });
+    });
+    const port = await listen(server);
+
+    const out = join(dir, `${(seq += 1)}-dropped.json`);
+    const r = await spawnJudge([writeInput([finding("[P1] x")]), "--model", "m", "--out", out], {
+      OCR_LLM_URL: `http://127.0.0.1:${port}/v1/chat/completions`,
+      OCR_LLM_TOKEN: "t",
+    });
+    await new Promise((res2) => server.close(res2));
+
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /could not complete the LLM request/);
+    assert.doesNotMatch(r.stderr, /node:internal/, "the body read must be inside the catch");
     assert.equal(existsSync(out), false);
   });
 

--- a/scripts/judge.test.mjs
+++ b/scripts/judge.test.mjs
@@ -632,9 +632,28 @@ describe("malformed-but-parseable responses name themselves on the first line", 
     });
   }
 
-  // The falsy cases are NOT a schema violation — they mean the judge classified
-  // nothing, which the fail-open pass handles deliberately. Guarding the truthy
-  // non-arrays must not sweep these up.
+  // FALSY IS NOT THE SAME QUESTION AS ABSENT, and conflating them is what the
+  // first version of this guard did. `false`, `0`, `""` and `NaN` are falsy AND
+  // non-arrays, so a truthiness test let them through to `|| []`: every finding
+  // came out unclassified, the fail-open pass kept all of them, and the judge
+  // exited 0 — publishing every finding as JUDGED off a response that violated
+  // the schema, under `precision-filter: true`. A reject-list guard reintroduced
+  // the exact hole it looked like it was closing.
+  //
+  // Asserting the exit code is not enough on its own here: the failure mode was
+  // a SUCCESSFUL exit, so these also assert that no output was written.
+  for (const [name, groups] of [["false", "false"], ["0", "0"], ['""', '""']]) {
+    test(`groups is ${name} — falsy but still a schema violation`, async () => {
+      const r = await judge({ comments: [finding("[P1] x")], reply: `{"groups":${groups}}` });
+      assert.notEqual(r.status, 0, "a falsy non-array must not publish findings as judged");
+      assert.match(r.stderr.split("\n")[0], /judge returned a non-array groups/);
+      assert.equal(existsSync(r.out), false, "nothing may be written on a schema violation");
+    });
+  }
+
+  // The two exemptions are named on purpose and mean "the judge classified
+  // nothing", which the fail-open pass handles deliberately. Tightening the
+  // guard must not sweep them up.
   for (const [name, groups] of [["absent", "{}"], ["null", '{"groups":null}']]) {
     test(`groups ${name} still falls open, not closed`, async () => {
       const r = await judge({ comments: [finding("[P1] x")], reply: groups, threshold: 0.7 });

--- a/scripts/judge.test.mjs
+++ b/scripts/judge.test.mjs
@@ -589,6 +589,61 @@ describe("transport and envelope failures", () => {
   });
 });
 
+// A 200 WITH THE WRONG SHAPE MUST STILL NAME ITSELF. action.yml promotes the
+// FIRST line of this script's stderr into the job's user-facing L2 failure
+// reason, so a throw from a malformed-but-parseable response reported
+// `judge.mjs:195` as why the review failed — a source location, naming nothing
+// and implying no fix.
+//
+// Every assertion here checks the first line specifically, because that is the
+// only line the operator sees. A fix that printed a good message *after* a stack
+// trace would pass a plain `match` and change nothing.
+describe("malformed-but-parseable responses name themselves on the first line", () => {
+  const firstLine = (r) => r.stderr.split("\n")[0];
+  const notASourceLocation = (r) => {
+    assert.doesNotMatch(firstLine(r), /judge\.mjs:\d+/, "a source location is not a diagnosis");
+    assert.doesNotMatch(firstLine(r), /^node:internal/, "a node internal is not a diagnosis");
+  };
+
+  // The envelope parses and `content` is present but unreadable, so extraction
+  // succeeds and the `.replace` after it used to throw.
+  for (const [name, content] of [["null", null], ["a number", 42], ["an object", { a: 1 }]]) {
+    test(`content is ${name}`, async () => {
+      const r = await judge({
+        comments: [finding("[P1] x")],
+        envelope: JSON.stringify({ choices: [{ message: { content } }] }),
+      });
+      assert.equal(r.status, 1);
+      assert.match(firstLine(r), /judge response had no text content/);
+      notASourceLocation(r);
+    });
+  }
+
+  // A string iterates by character and an object is not iterable at all, so
+  // these threw a few lines further down. Failing is right rather than falling
+  // open: falling open keeps every finding unjudged, the one outcome the judge
+  // exists to prevent.
+  for (const [name, groups] of [["a string", '"nope"'], ["an object", '{"a":1}'], ["a number", "7"]]) {
+    test(`groups is ${name}`, async () => {
+      const r = await judge({ comments: [finding("[P1] x")], reply: `{"groups":${groups}}` });
+      assert.equal(r.status, 1);
+      assert.match(firstLine(r), /judge returned a non-array groups/);
+      notASourceLocation(r);
+    });
+  }
+
+  // The falsy cases are NOT a schema violation — they mean the judge classified
+  // nothing, which the fail-open pass handles deliberately. Guarding the truthy
+  // non-arrays must not sweep these up.
+  for (const [name, groups] of [["absent", "{}"], ["null", '{"groups":null}']]) {
+    test(`groups ${name} still falls open, not closed`, async () => {
+      const r = await judge({ comments: [finding("[P1] x")], reply: groups, threshold: 0.7 });
+      assert.equal(r.status, 0, r.stderr);
+      assert.equal(r.read().comments.length, 1, "an unclassified finding is kept");
+    });
+  }
+});
+
 describe("request shape", () => {
   test("the model, a zero temperature and bearer auth are sent", async () => {
     const r = await judge({

--- a/scripts/judge.test.mjs
+++ b/scripts/judge.test.mjs
@@ -498,6 +498,52 @@ describe("transport and envelope failures", () => {
     assert.match(r.stderr, /judge did not return JSON/);
   });
 
+  // AN UNREACHABLE GATEWAY IS A FAILURE CLASS TOO, and it has to arrive named.
+  // `fetch` rejects rather than returning a response when it cannot reach the
+  // endpoint at all, so with no catch the process died on an unhandled rejection
+  // and the first line of stderr was a path inside undici. action.yml quotes
+  // that first line as the reason in its summary annotation, which turned "the
+  // gateway is unreachable" into a stack frame — no class, no fix implied.
+  //
+  // The no-stack-trace assertion is the load-bearing one: a `catch` that merely
+  // re-printed the error would still satisfy the message match.
+  test("an unreachable endpoint is named, not a stack trace", async () => {
+    // A port that was bound and released is reliably closed, unlike a guess.
+    const probe = http.createServer();
+    const closedPort = await listen(probe);
+    await new Promise((r) => probe.close(r));
+
+    const out = join(dir, `${(seq += 1)}-unreachable.json`);
+    const r = await spawnJudge([writeInput([finding("[P1] x")]), "--model", "m", "--out", out], {
+      OCR_LLM_URL: `http://127.0.0.1:${closedPort}/v1/chat/completions`,
+      OCR_LLM_TOKEN: "t",
+    });
+
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /could not reach the LLM/);
+    assert.match(r.stderr, /ECONNREFUSED/, "the cause carries the part worth reading");
+    assert.doesNotMatch(r.stderr, /node:internal/, "an unhandled rejection must not be the diagnostic");
+    assert.equal(existsSync(out), false);
+  });
+
+  // Every terminal failure names its class on the FIRST line, because that is
+  // the line action.yml lifts into the summary. The judge's bad-reply message is
+  // followed by a dump of what the model actually said, so a `tail` would quote
+  // a fragment of the bad completion in place of the reason.
+  test("the first stderr line names the class, for every terminal failure", async () => {
+    const cases = [
+      [{ status: 400, reply: "{}" }, /^HTTP 400: /],
+      [{ status: 401, reply: "{}" }, /^HTTP 401: /],
+      [{ envelope: "not json at all" }, /^bad completion envelope: /],
+      [{ reply: "Sure! Here are my thoughts\nabout the finding." }, /^judge did not return JSON:$/],
+    ];
+    for (const [opts, expected] of cases) {
+      const r = await judge({ comments: [finding("[P1] x")], reply: "{}", ...opts });
+      assert.equal(r.status, 1);
+      assert.match(r.stderr.split("\n")[0], expected);
+    }
+  });
+
   test("a fenced ```json reply is unwrapped", async () => {
     const r = await judge({
       comments: [finding("[P1] x")],

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -99,8 +99,20 @@ function validateSettings(data) {
   // report_on rides in this loop because it is the same shape as the other two —
   // a comma-joined severity subset where "" is a deliberate "none" — but it
   // answers a different question: fix_first and block_on decide what the review
-  // ENFORCES, report_on only what it SHOWS. A gateway that predates the field
-  // omits it, which lands on the default above and behaves as before.
+  // ENFORCES, report_on only what it SHOWS.
+  //
+  // A RESPONSE THAT OMITS THE FIELD LANDS ON THE DEFAULT ABOVE, and that is no
+  // longer the same thing as "behaves as before" — this comment used to say so
+  // and was left standing when the default moved from all four severities to
+  // P0,P1. An omitted field now resolves to P0,P1, and since the report filter
+  // shows report_on UNION block_on (block_on also defaulting to P0,P1), P2/P3
+  // are not recovered anywhere else.
+  //
+  // Which is deliberate, and rests on a fact rather than on compatibility: the
+  // gateway sets P0,P1 itself for every workspace that has not chosen a value,
+  // so an omitted field means "this workspace never set one", not "this server
+  // is too old to have the field". Reproducing the answer we could not fetch is
+  // the whole job of a failure default, and the answer is P0,P1.
   for (const field of ["fix_first", "block_on", "report_on"]) {
     const normalized = normalizeSeverityList(data[field]);
     if (normalized !== null) out[field] = normalized;

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -47,16 +47,21 @@ const DEFAULTS = Object.freeze({
   quiet: false,
   fix_first: "P0,P1",
   block_on: "P0,P1",
-  // EVERY severity, and this is the FAILURE value rather than the product
-  // default. A workspace created after report_on shipped gets P0,P1 written
-  // explicitly by the gateway, while one that predates the setting still
-  // resolves to every severity — so no single value here can match "what this
-  // workspace normally sees".
+  // THE VALUE THE GATEWAY WOULD HAVE GIVEN, which is the whole job of a failure
+  // default: reproduce the answer we could not fetch.
   //
-  // So it fails OPEN. An install that normally shows P2/P3 must not lose them
-  // because a settings call timed out; the opposite mistake only shows a reader
-  // more than they asked for, once, in a run that already logged a fetch failure.
-  report_on: "P0,P1,P2,P3",
+  // This used to be every severity, on the reasoning that a workspace predating
+  // report_on resolved to all four, so no single value could match "what this
+  // workspace normally sees" — and losing P2/P3 to a timeout was judged worse
+  // than showing them once. That premise expired. The gateway's own default is
+  // now P0,P1 for every workspace that has not set the field, so all-severities
+  // matches nothing any more: on a settings outage it published P2/P3 to
+  // installs that would never have been shown them.
+  //
+  // Which is not a cosmetic mistake here. These severities are the ones the
+  // judge exists to filter, so an outage that opens this up is also the outage
+  // most likely to have degraded the filtering.
+  report_on: "P0,P1",
   rubric: "",
 });
 

--- a/scripts/settings.test.mjs
+++ b/scripts/settings.test.mjs
@@ -45,10 +45,11 @@ const DEFAULTS = {
   quiet: false,
   fix_first: "P0,P1",
   block_on: "P0,P1",
-  // Fail-open, NOT the product default: this is what the action falls back to
-  // when the dashboard is unreachable, and an outage must never silently
-  // withhold findings. The configured default is narrower and lives server-side.
-  report_on: "P0,P1,P2,P3",
+  // What the action falls back to when the dashboard is unreachable. It mirrors
+  // the gateway's own default for a workspace that never set the field, so an
+  // outage reproduces the answer it could not fetch. Kept in sync with
+  // settings.mjs DEFAULTS — see the reasoning there.
+  report_on: "P0,P1",
   rubric: "",
 };
 
@@ -247,7 +248,7 @@ describe("settings: field-wise fallback on invalid values", () => {
         quiet: false,
         fix_first: "P0,P1",
         block_on: "P0,P1",
-        report_on: "P0,P1,P2,P3",
+        report_on: "P0,P1",
         rubric: "",
       });
       assert.match(r.stderr, /trigger/, "field fallbacks must be noted on stderr");


### PR DESCRIPTION
Reported from the field: a review that had already run for eleven minutes was
discarded after the L2 judge call got a 502, and a re-run with the judge
disabled failed too. Tracing it turned up four things — and then review of this
PR turned up that the first of them was wrong. Both are below.

## Withdrawn: the judge retry

The first version of this PR gave `judge.mjs` a four-attempt 5xx retry, on the
reading that every other LLM call in the pipeline had one and this call did not.

That reading was wrong. In production `OCR_LLM_URL` points at the local fact
proxy this action starts, and the proxy already retries 429/502/503/504 four
times with backoff. A loop in `judge.mjs` does not add resilience, it
multiplies: four attempts here times four there is sixteen upstream requests
for one judge call.

It was also a wider status set than the proxy's, and the proxy's narrowness is
deliberate — it excludes 500 because a 500 can mean the completion was produced
and billed, so replaying it buys the same bill twice. The outer loop would have
re-sent exactly that, bypassing a policy it did not know existed.

Which also means the reported 502 was never an unretried call. It was the
answer after the proxy had already spent its retries. No amount of asking again
would have changed it.

The code is gone. In its place is a comment saying why the retry is
deliberately absent, and a test pinning the request count at one — so the next
reader with the same good idea meets a red test instead of a merge.

## L2 is no longer soft-fail

This is the change that actually addresses the report, and it is a **behaviour
change** worth calling out in the release notes.

L1's output is not a shippable review. It is the engine's raw findings with
mismatched snippets re-homed — still carrying the duplicate and low-value
findings L2 exists to cluster and drop. Publishing it because the judge was
unreachable shipped exactly the noise the filter was turned on to remove, and
it arrived looking like a finished review.

`precision-filter: "false"` remains the supported way to review without a
judge. It skips L1 too, which is the honest version of that choice. The input
description now says which layer is soft and which is not.

## The failure messages were indistinguishable

An engine crash, a partial run, and an unavailable judge all printed one
`no usable result`. A reader could not tell which gate closed, so they picked
whichever cause was last in the log — which is how a run whose judge logged a
502 shortly before an unrelated failure got read as the judge throwing the
review away.

Each cause now names itself in the summary, and `check-result.mjs` tags its
four reasons (`reason=engine-exit|unparseable|no-comments|partial`) for anyone
grepping.

## The report_on failure default matched nothing

It was every severity, on the reasoning that a workspace predating `report_on`
resolved to all four, so no single value could match "what this workspace
normally sees". That premise expired. The gateway sets `P0,P1` itself for any
workspace that has not chosen a value, so all-severities matched nothing — and
a settings outage published P2/P3 to installs that would never have been shown
them.

Wrong in both directions at once, because the outage that opens this up is also
the one most likely to have degraded the filtering that makes those severities
worth reading. The stale reasoning is replaced along with the value, so the next
reader does not restore it from the comment.

Left alone deliberately: the dashboard-disabled path still emits every
severity. Its reason is different and still holds — with no dashboard there is
no `report_on` to reproduce, and the workflow file has no input for it.

## What review found

Seven rounds, and worth reading as a set, because almost every finding was a
defect in the *previous* round's fix rather than in the original code. Only one
of the twelve pointed at code that existed before this branch.

- **The retry itself** (the P1 above) — withdrawn.
- **`warnings` read two ways.** The skip-the-filter optimization tested
  `(r.warnings||[]).length` while the check tests `Array.isArray(...) ? ... : []`.
  A `warnings` of `"oops"` measures 4, so the gate called it partial and
  skipped L1+L2, and the check normalized it to `[]` and published — the
  engine's raw findings, unjudged, under `precision-filter: true`, arriving as
  a green review. Which also fixed the direction the predicate must fail in:
  skipping is the branch that can publish unjudged, so it may only be taken
  when the result is definitely partial.
- **"after retries" was false for most failures.** A 400, a 401, an
  unparseable envelope and a model answering in prose all reached that
  sentence. The reason is carried now instead of asserted, and the marker file
  that was being written and then ignored actually carries it.
- **An unreachable gateway had no class at all**, then **a mid-body drop still
  had none**. `fetch` rejects when it cannot connect but RESOLVES once headers
  arrive, so the two are different frames and the first fix only covered one.
  fact-proxy relays headers and then destroys the connection on a mid-stream
  upstream failure, so the uncovered frame was the likelier one in production.
- **A green run carrying a red annotation.** The judge branch printed
  `::error:: ... failing closed`, but on a best-effort exhaustive pass
  `run_review` warns, keeps the findings, and the job succeeds. The branch
  states the fact now and both callers own the consequence, which is what the
  wall-clock marker beside it already did.
- **A malformed 200 reported a line number.** `content` not a string, or
  `groups` non-array, threw outside every handler — so the operator's failure
  reason was `judge.mjs:195`. Guarded, plus a backstop for the shapes nobody
  enumerated, because enumerating shapes is always one shape short.
- **And then that guard had falsy holes.** It tested `groups &&
  !Array.isArray(groups)`, so `false`, `0` and `""` walked past into `|| []`:
  every finding came out unclassified, the fail-open pass kept all of them, and
  the judge exited 0 — publishing every finding as JUDGED off a
  schema-violating response, as a green review. The guard reopened the hole it
  was added to close. The test now names what is ALLOWED (absent, null, or an
  array) instead of what is rejected, a shape that cannot have this kind of
  miss. Third time in this branch that enumerating bad values came up one
  short, and every time the miss landed on the publishing side.
- **Two cleanup misses**, both the same shape: a new artefact added without
  touching the list that already enumerates every artefact of its kind
  (`judge-unavailable`, then `result.l2.log`).

## Verification

565 tests, 556 passing, and the failure set is byte-identical to this branch's
base — 9 pre-existing and unrelated (CLI import, skill templates, and
Windows-only `0xC0000409` crashes in the settings/report spawn tests).

Behaviour was checked by running it, not by reading it:

- All six judge failure classes end to end against a stub gateway — HTTP 400,
  HTTP 401, bad completion envelope, non-JSON reply, ECONNREFUSED, and a
  connection destroyed mid-body — each naming itself on the first line, which
  is the only line the summary promotes.
- The action's own plumbing extracted and driven with a stub judge per class:
  the summary line came out distinct and accurate every time, including
  `it exited cleanly but wrote no output` and `it exited 9 without a message`.
- The real `run_review` extracted and driven with a judge that fails on the
  mandatory pass and then on the best-effort pass: `::error:: ... failing closed`
  with a nonzero exit for the first, only a `::warning:: ... keeping the findings
  so far` and exit 0 for the second.
- Every shape a `warnings` field can take — array, empty array, absent, null,
  string, number, object — asserting the *pairing*: there is no case where the
  filter is skipped and the check publishes.
- Leftover files after each failure path listed and checked against the cleanup
  lists.
- Every non-array `comments` value — string, number, object, boolean, null,
  absent — through the gate and the check together, after the same mistake shape
  turned up in `groups`. All six fail closed; the publishing side is sound.
- Every `run:` block re-parsed as YAML and syntax-checked with `bash -n`.

New tests are mutation-checked rather than trusted for being green: reverting
each fix in turn reds exactly the tests that cover it and no others. That
matters here because the regression test for the `warnings` agreement extracts
the real predicate out of `action.yml` and runs it, and its match deliberately
does not require the `Array.isArray` spelling — a test that only noticed a
missing token would go red for the wrong reason and prove nothing.
