### PR TITLE
feat: raise the diff limits so a large PR gets reviewed instead of refused

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -95,12 +95,31 @@ inputs:
       KB. A skip posts a notice without running the engine; whether the check
       then fails or passes is `on-oversized-diff` (default: fail, so the
       merge gate cannot be padded around).
+
+
+      The default is a ceiling on WASTE, not on what the engine can handle.
+      It used to be 512, chosen to avoid spending tokens on diffs that review
+      badly — but it also meant a large PR could never be reviewed at all, and
+      "never" is worse than "expensive". The engine reads the diff through its
+      own tooling rather than taking it as one prompt, so size alone does not
+      decide whether it can work.
+
+
+      What DOES bound it is the model's context window, which the action cannot
+      see. Past that point a run reports a wall-clock timeout or an aborted
+      pass instead of a clean skip — louder, and no longer a silent refusal to
+      look. Lower this if you would rather have the clean skip back.
     required: false
-    default: "512"
+    default: "5000"
   max-diff-files:
-    description: "Skip the review when the diff touches more than this many files (same notice + on-oversized-diff outcome as max-diff-kb)."
+    description: >-
+      Skip the review when the diff touches more than this many files (same
+      notice + on-oversized-diff outcome as max-diff-kb). Counted separately
+      from size because the two describe different shapes: a mechanical rename
+      across 900 files is small and shallow, one 4 MB generated file is large
+      and shallow, and either can be worth reviewing.
     required: false
-    default: "300"
+    default: "2000"
   on-oversized-diff:
     description: >-
       What an oversized-diff skip does to the check. "fail" (default) fails
@@ -134,11 +153,17 @@ inputs:
       hasn't produced a result within this window it is killed and the run
       fails closed with a distinct "wall-clock timeout" error (separate from
       "no usable result", so the log makes clear which mode failed). Accepts
-      decimals (e.g. "0.5" = 30 seconds) for testing. Default 20 covers most
-      PRs on shipped models; bump for very large diffs or slow-per-call
-      models where per-file review takes longer.
+      decimals (e.g. "0.5" = 30 seconds) for testing.
+
+
+      PER PASS, which matters more now that the default is 60: `exhaustive`
+      mode makes up to three passes, so the worst case is three times this
+      number. The default rose with the diff limits — a review allowed to
+      accept a much larger diff needs the time to actually read it, and 20
+      minutes would have converted "too big, skipped cleanly" into "killed
+      halfway", which is the same non-review with a worse message.
     required: false
-    default: "20"
+    default: "60"
   precision-filter:
     description: >-
       Post-processing between the engine and the merge gate. When `"true"`
@@ -665,7 +690,7 @@ runs:
             `lose signal — ${outcome}\n\n` +
             `**What now?** Split the PR (smaller diffs get much higher-signal reviews), raise ` +
             `the limits, or make skips advisory:\n\n` +
-            '```yaml\nwith:\n  max-diff-kb: "1024"        # default 512\n  max-diff-files: "500"      # default 300\n  on-oversized-diff: "pass"  # default "fail"\n```' +
+            '```yaml\nwith:\n  max-diff-kb: "10000"       # default 5000\n  max-diff-files: "4000"     # default 2000\n  on-oversized-diff: "pass"  # default "fail"\n```' +
             footer;
 
           const comments = await github.paginate(github.rest.issues.listComments, {

--- a/scripts/diff-guard.mjs
+++ b/scripts/diff-guard.mjs
@@ -13,8 +13,10 @@
 // not an error:
 //   {"decision":"review"|"skip","reason":"…","size_kb":<n>,"files":<n>}
 //
-// Defaults: 512 KB / 300 files (surfaced as the action's `max-diff-kb` /
-// `max-diff-files` inputs). The size check is decided from stat() alone — an
+// Defaults: 5000 KB / 2000 files (surfaced as the action's `max-diff-kb` /
+// `max-diff-files` inputs, and they must agree — a caller that passes an
+// empty flag lands here, so a stale number in this file would quietly give a
+// different limit than the documented one). The size check is decided from stat() alone — an
 // oversized diff is never read into memory, so a size-skip reports files: 0
 // (not counted). Only an under-cap diff is read to count files. `files`
 // counts `diff --git` file headers — in a unified diff every content line is
@@ -39,8 +41,8 @@ for (let i = 0; i < argv.length; i += 1) {
   else if (argv[i] === "--max-kb") maxKbRaw = argv[++i];
   else if (argv[i] === "--max-files") maxFilesRaw = argv[++i];
 }
-const maxKb = positive(maxKbRaw, 512);
-const maxFiles = positive(maxFilesRaw, 300);
+const maxKb = positive(maxKbRaw, 5000);
+const maxFiles = positive(maxFilesRaw, 2000);
 
 function decide() {
   if (!diffPath) {

--- a/scripts/diff-guard.test.mjs
+++ b/scripts/diff-guard.test.mjs
@@ -6,7 +6,7 @@
 // throwing anywhere below would fail the test), and anything unreadable fails
 // OPEN to "review" so a guard glitch can never silently disable the review.
 //
-// Limits: --max-kb (default 512) on byte size, --max-files (default 300) on
+// Limits: --max-kb (default 5000) on byte size, --max-files (default 2000) on
 // `diff --git` headers. AT a limit still reviews; only strictly-over skips.
 
 import { execFileSync } from "node:child_process";
@@ -107,26 +107,82 @@ describe("file-count threshold (--max-files)", () => {
   });
 });
 
-describe("defaults (512 KB / 300 files)", () => {
-  test("a >512 KB diff skips with no flags given", () => {
-    const out = run(["--diff", writeDiff(`diff --git a/a b/a\n+${"x".repeat(513 * 1024)}\n`)]);
+describe("defaults (5000 KB / 2000 files)", () => {
+  test("a >5000 KB diff skips with no flags given", () => {
+    const out = run(["--diff", writeDiff(`diff --git a/a b/a\n+${"x".repeat(5001 * 1024)}\n`)]);
     assert.equal(out.decision, "skip");
-    assert.match(out.reason, /over the 512 KB limit/);
+    assert.match(out.reason, /over the 5000 KB limit/);
   });
 
-  test("301 files skips, 300 reviews, with no flags given", () => {
+  test("2001 files skips, 2000 reviews, with no flags given", () => {
+    // ~90 bytes per block, so 2001 of them is ~180 KB — far under the size
+    // limit, which is what makes this a file-COUNT test and not a size one.
     let many = "";
-    for (let i = 0; i < 301; i += 1) many += fileBlock(i);
+    for (let i = 0; i < 2001; i += 1) many += fileBlock(i);
     assert.equal(run(["--diff", writeDiff(many)]).decision, "skip");
 
     let exactly = "";
-    for (let i = 0; i < 300; i += 1) exactly += fileBlock(i);
+    for (let i = 0; i < 2000; i += 1) exactly += fileBlock(i);
     assert.equal(run(["--diff", writeDiff(exactly)]).decision, "review");
   });
 
   test("a non-numeric limit falls back to its default instead of crashing", () => {
     const out = run(["--diff", writeDiff(fileBlock(1)), "--max-kb", "banana"]);
     assert.equal(out.decision, "review");
+  });
+});
+
+// THE FALLBACK AND THE DOCUMENTED DEFAULT ARE ONE NUMBER IN TWO PLACES, and
+// this pins them together. action.yml passes `--max-kb "$MAX_KB"` QUOTED, so a
+// workspace that sets `max-diff-kb: ""` reaches this script as an empty
+// argument and lands on the fallback — which means a stale number here would
+// silently enforce a limit nobody documented, and no test would notice.
+//
+// Read out of action.yml rather than restated, so editing one side without the
+// other fails here instead of in production.
+describe("the script's fallbacks match action.yml's documented defaults", () => {
+  // NEWLINES NORMALIZED, because this repo has no `.gitattributes` and
+  // `core.autocrlf` is the Windows default: every Windows checkout gets a CRLF
+  // action.yml, and the anchors below are written with bare "\\n". Without this the
+  // test passes on Linux CI and fails on every Windows machine — a shape worth
+  // avoiding on purpose, since CI green would be read as "works".
+  const actionYml = () =>
+    readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "action.yml"), "utf8").replace(
+      /\r\n/g,
+      "\n",
+    );
+
+  // The block for ONE input: from its key to the next key at the same indent.
+  // Bounded rather than a non-greedy scan of the whole file, so an input with
+  // no numeric default fails the assert instead of quietly borrowing a later
+  // input's.
+  function inputDefault(name) {
+    const yml = actionYml();
+    const start = yml.indexOf(`\n  ${name}:\n`);
+    assert.notEqual(start, -1, `${name} must exist in action.yml`);
+    const rest = yml.slice(start + 1);
+    const next = rest.search(/\n  [a-z][a-z0-9-]*:\n/);
+    const block = next === -1 ? rest : rest.slice(0, next);
+    const m = block.match(/\n    default: "(\d+)"/);
+    assert.ok(m, `${name} must have a numeric default in action.yml`);
+    return Number(m[1]);
+  }
+
+  test("an empty --max-kb enforces action.yml's max-diff-kb", () => {
+    const documented = inputDefault("max-diff-kb");
+    const oversized = `diff --git a/a b/a\n+${"x".repeat((documented + 1) * 1024)}\n`;
+    const out = run(["--diff", writeDiff(oversized), "--max-kb", ""]);
+    assert.equal(out.decision, "skip");
+    assert.match(out.reason, new RegExp(`over the ${documented} KB limit`));
+  });
+
+  test("an empty --max-files enforces action.yml's max-diff-files", () => {
+    const documented = inputDefault("max-diff-files");
+    let many = "";
+    for (let i = 0; i < documented + 1; i += 1) many += fileBlock(i);
+    const out = run(["--diff", writeDiff(many), "--max-files", ""]);
+    assert.equal(out.decision, "skip");
+    assert.match(out.reason, new RegExp(`over the ${documented}-file limit`));
   });
 });
 

--- a/skills/orca-review-action/assets/workflow.yml
+++ b/skills/orca-review-action/assets/workflow.yml
@@ -55,7 +55,7 @@ jobs:
           # fix-first: "P0,P1"          # exhaustive only: stop adding passes once found
           # on-oversized-diff: "fail"   # "pass" makes an oversized skip advisory
           # auto-review-authors: ""     # public repos: e.g. "OWNER,MEMBER,COLLABORATOR,CONTRIBUTOR"
-          # max-diff-kb: "512"
-          # max-diff-files: "300"
-          # timeout-minutes: "20"
+          # max-diff-kb: "5000"
+          # max-diff-files: "2000"
+          # timeout-minutes: "60"
           # report: "true"              # severity counts only — never code

--- a/skills/orca-review-action/references/inputs.md
+++ b/skills/orca-review-action/references/inputs.md
@@ -44,8 +44,8 @@ allowlist and put a budget + alert on the key.
 
 | Input | Default | What it does |
 | --- | --- | --- |
-| `max-diff-kb` | `512` | Skip the review when the merge-base diff exceeds this size. |
-| `max-diff-files` | `300` | Skip when the diff touches more files than this. |
+| `max-diff-kb` | `5000` | Skip the review when the merge-base diff exceeds this size. Raised from 512 so large PRs are reviewed rather than refused; the real ceiling is the model context window, which this cannot see. |
+| `max-diff-files` | `2000` | Skip when the diff touches more files than this. Raised from 300. |
 | `on-oversized-diff` | `fail` | What a skip does to the check. `fail` means a diff padded past the limits cannot bypass a required gate. `pass` restores advisory behavior. |
 
 The guard runs **before** the engine, so an oversized PR costs nothing.
@@ -67,7 +67,7 @@ an error keeps the prior stage's findings and never aborts the review.
 | --- | --- | --- |
 | `concurrency` | `24` | Max concurrent file reviews. Raise to shorten wall clock; lower it under a tight per-minute request quota. |
 | `max-tools` | `""` (engine default) | Max tool-call rounds per file. Lowering cuts cost and time but can cost review depth. |
-| `timeout-minutes` | `20` | Wall-clock ceiling for **one** engine pass. Exceeding it fails closed with a distinct "wall-clock timeout" error. Accepts decimals. Bump for very large diffs or slow models. |
+| `timeout-minutes` | `60` | Wall-clock ceiling for **one** engine pass — `exhaustive` makes up to three, so the worst case is 3x this. Exceeding it fails closed with a distinct "wall-clock timeout" error. Accepts decimals. Raised from 20 alongside the diff limits: a larger diff needs the time to actually be read. |
 
 ## Control plane
 

--- a/skills/orca-review-action/references/troubleshooting.md
+++ b/skills/orca-review-action/references/troubleshooting.md
@@ -108,7 +108,7 @@ the console rather than in the file.
 
 ## The run times out
 
-`timeout-minutes` (default 20) is a ceiling on **one** engine pass. Exceeding it
+`timeout-minutes` (default 60) is a ceiling on **one** engine pass. Exceeding it
 fails closed with a distinct "wall-clock timeout" error, separate from
 "no usable result" — the log says which. Raise it for very large diffs or
 slow-per-call models, or lower `concurrency` if the model is rate-limiting and the

--- a/workflows/orca-code-review.yml
+++ b/workflows/orca-code-review.yml
@@ -60,9 +60,9 @@ jobs:
           # router: "orcarouter/orcacode-review"  # router whose DSL picks the model
           # fix-first: "P0,P1"   # exhaustive only: stop adding passes once one is found
           # block-on: "P0"       # fail the check (block merge) on these
-          # max-diff-kb: "512"   # bigger diffs skip the review (outcome: on-oversized-diff)
-          # max-diff-files: "300"  # same skip when the diff touches more files than this
+          # max-diff-kb: "5000"   # bigger diffs skip the review (outcome: on-oversized-diff)
+          # max-diff-files: "2000"  # same skip when the diff touches more files than this
           # on-oversized-diff: "fail"  # oversized skip fails the check; "pass" makes it advisory
           # settings: "true"     # "false" skips the dashboard fetch — this file is authoritative
           # report: "true"       # per-run severity counts (never code) to your control plane
-          # timeout-minutes: "20"  # wall-clock ceiling per engine pass; bump for very large PRs
+          # timeout-minutes: "60"  # wall-clock ceiling per engine pass; bump for very large PRs


### PR DESCRIPTION
A large PR currently cannot be reviewed at all. The diff guard skips at 512 KB
or 300 files, posts a notice, and by default fails the check — so past that
size the answer is permanently "no review", not "a worse review".

This raises the three numbers that decide that: **512 KB → 5000 KB**,
**300 files → 2000 files**, **20 minutes → 60 minutes**.

## Why the old numbers were the wrong test

They were a ceiling on *waste*, chosen so tokens were not spent on diffs that
review badly. That reasoning is sound and the ceiling is kept — just much
higher — because the side effect was worse than the cost it avoided: "never
reviewed" beats "expensive review" only if the expensive review is useless, and
it is not.

Size alone was never the right proxy either. The engine reads the diff through
its own tooling rather than taking it as one prompt, so a 2 MB diff is not
automatically beyond it.

The two limits stay separate because they describe different shapes. A
mechanical rename across 900 files is small and shallow; one 4 MB generated
file is large and shallow; either can be worth reviewing, and neither is
described by the other's number.

## What this trades away, stated plainly

The real ceiling is the model's context window, and the action cannot see it —
it is handed a model string, and the actual route is decided by the workspace's
recipe. Past that point a run reports a wall-clock timeout or an aborted pass
instead of a clean skip.

So this swaps a cheap, tidy refusal for a real attempt that can fail late and
loudly. That is the intended direction — a loud failure after trying is more
useful than a silent refusal to look — but it is a trade, not a free win, and
it is written into the `max-diff-kb` description along with how to get the old
behaviour back.

The timeout had to move in the same commit rather than a later one. At 20
minutes a review allowed to accept a much larger diff would simply have been
killed halfway: the same non-review as before, with a worse message. It is a
**per-pass** ceiling and `exhaustive` makes up to three passes, which is worth
saying out loud now that 3 × 60 is a different proposition from 3 × 20.

## Every place that states these numbers

They moved together, because a number stated in seven places is seven chances
to disagree:

- the `max-diff-kb` / `max-diff-files` / `timeout-minutes` inputs
- `diff-guard.mjs`'s own fallbacks and header
- the oversized-diff notice posted on the PR — its example values were
  `1024` / `500`, which after this change would have been advice to **lower**
  the limit
- the example workflow and the skill's workflow template
- the skill's input reference and troubleshooting reference

## The fallbacks are pinned to the inputs now

`diff-guard.mjs`'s defaults and the action's input defaults are one number in
two places, and the second is reachable rather than theoretical: action.yml
passes `--max-kb "$MAX_KB"` **quoted**, so a workspace that sets
`max-diff-kb: ""` arrives here as an empty argument and lands on the script
fallback. A stale number there would enforce a limit nobody documented, with
nothing failing.

There is a test for that now. It reads the default out of `action.yml` rather
than restating it, and is mutation-checked in both directions: editing only the
script reds it, and editing only `action.yml` reds it too — the second being
the case that previously had no coverage at all.

## A defect in that test, found before it shipped

Worth recording because of *how* it would have failed. The test anchored on
bare `"\n"`, and this repo has no `.gitattributes` while `core.autocrlf` is the
Windows default — so `action.yml` is CRLF in every Windows checkout. It would
have passed on Linux CI forever and failed on every developer machine, and CI
green reads as "works".

Found by A/B-ing the failure set across a `git stash` round-trip, which is what
converted the file's line endings and made the difference visible. Newlines are
normalized on read now, mutation-checked against the CRLF working copy.

A repo-wide `.gitattributes` would fix the underlying fragility for every test
that reads a tracked file, but it renormalizes the whole tree and does not
belong in this change.

## Verification

567 tests, 558 passing, failure set **identical** to `main`'s — 9 pre-existing
and unrelated (CLI import, skill packaging, and Windows-only `0xC0000409`
crashes in the settings/report spawn tests).

The defaults are exercised at their real values, not asserted as constants: a
5001 KB diff skips with no flags, 2001 files skip and 2000 review. The
file-count fixture is ~180 KB — far under the size limit — so it still tests
the count rather than accidentally re-testing the size.

Also worth flagging separately from this change: the pre-existing failure set
is not stable run to run. Two of the nine swap places between runs (a workflow
template comparison and a settings-input assertion), which means something in
the suite is order- or parallelism-sensitive. Nothing here touches it, and no
number in this PR was chosen on the basis of that set.
